### PR TITLE
Upgrade qenvs to version v0.0.5

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -32,7 +32,8 @@ jobs:
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
             --vmsize 'Standard_D8a_v4' \
-            --tags project=podman-desktop 
+            --tags project=podman-desktop \
+            --spot
         # Check logs 
         podman logs -f windows-create
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,7 +24,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.4-snapshot azure \
+          quay.io/rhqp/qenvs:v0.0.5 azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -32,7 +32,7 @@ jobs:
             --windows-version '${{ matrix.windows-version }}' \
             --windows-featurepack '${{ matrix.windows-featurepack }}' \
             --vmsize 'Standard_D8a_v4' \
-            --tags project=podman-desktop
+            --tags project=podman-desktop 
         # Check logs 
         podman logs -f windows-create
 
@@ -96,7 +96,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.4-snapshot azure \
+          quay.io/rhqp/qenvs:v0.0.5 azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'


### PR DESCRIPTION
This PR will change the version for qenvs within the windows gh action to make use of an released version of qenvs, in addition that version will include a new feature to use spot instances for windows desktop on azure which will reduce the cost on nearly 90%