### PR TITLE
Update qenvs to 0.6.0, upversion windows feature packs

### DIFF
--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -23,7 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent']
+        windows-featurepack: ['22h2-ent', '23h2-ent']
+        exclude:
+        - windows-version: '10'
+          windows-featurepack: '23h2-ent'
+        - windows-version: '11'
+          windows-featurepack: '22h2-ent'
 
     steps:
     - name: Set the default env. variables
@@ -43,7 +48,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -151,7 +156,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/podman-nightly-e2e.yaml
+++ b/.github/workflows/podman-nightly-e2e.yaml
@@ -23,7 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent']
+        windows-featurepack: ['22h2-ent', '23h2-ent']
+        exclude:
+        - windows-version: '10'
+          windows-featurepack: '23h2-ent'
+        - windows-version: '11'
+          windows-featurepack: '22h2-ent'
 
     steps:
     - name: Set the default env. variables
@@ -43,7 +48,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -157,7 +162,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: ['10', '11']
-        windows-featurepack: ['22h2-ent']
+        windows-version: ['10','11']
+        windows-featurepack: ['22h2-ent', '23h2-ent']
+        exclude:
+        - windows-version: '10'
+          windows-featurepack: '23h2-ent'
+        - windows-version: '11'
+          windows-featurepack: '22h2-ent'
 
     steps:
     - name: Create instance
@@ -24,7 +29,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -115,7 +120,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:v0.0.6-dev azure \
+          quay.io/rhqp/qenvs:v0.6.0 azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'


### PR DESCRIPTION
Updating `qenvs` image to use latest release version: `v0.6.0`. 

Also updating windows feature packs to its latest releases: https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information.

Now these combination should be run: 
* windows 10 + 22h2 feature pack
* windows 11 + 23h2 fp