### PR TITLE
fix: pd-e2e set x permissions on build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,9 +132,9 @@ jobs:
         name: ${{ matrix.os }}-${{ matrix.arch }}
         path: oci/bin/${{ matrix.os }}-${{ matrix.arch }}
 
-    - name: Check
+    - name: Set permissions
       shell: bash
-      run: ls oci/bin/${{ matrix.os }}-${{ matrix.arch }}
+      run: chmod +x oci/bin/${{ matrix.os }}-${{ matrix.arch }}
 
     - name: Build
       shell: bash


### PR DESCRIPTION
Fix #96 