### PR TITLE
Switch from QENVS images to MAPT

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -53,7 +53,8 @@ jobs:
       contents: read
       checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.6.8
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +90,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -212,7 +213,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -58,7 +58,8 @@ jobs:
       contents: read
       checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.6.8
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
@@ -93,7 +94,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -220,7 +221,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows.yaml
@@ -43,7 +43,8 @@ jobs:
       contents: read
       checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.6.8
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +82,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -203,7 +204,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -33,7 +33,8 @@ jobs:
       contents: read
       checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.6.8
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
@@ -70,7 +71,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -191,7 +192,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'

--- a/.github/workflows/podman-e2e-windows.yaml
+++ b/.github/workflows/podman-e2e-windows.yaml
@@ -12,7 +12,8 @@ jobs:
       contents: read
       checks: write
     env:
-      QENVS_VERSION: v0.6.3
+      MAPT_VERSION: v0.6.8
+      MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +35,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows create \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace' \
@@ -126,7 +127,7 @@ jobs:
           -e ARM_SUBSCRIPTION_ID=${{ secrets.ARM_SUBSCRIPTION_ID }} \
           -e ARM_CLIENT_ID=${{ secrets.ARM_CLIENT_ID }} \
           -e ARM_CLIENT_SECRET='${{ secrets.ARM_CLIENT_SECRET }}' \
-          quay.io/rhqp/qenvs:${{ env.QENVS_VERSION }} azure \
+          ${{ env.MAPT_IMAGE }}:${{ env.MAPT_VERSION }} azure \
             windows destroy \
             --project-name 'windows-desktop' \
             --backed-url 'file:///workspace'


### PR DESCRIPTION
Moving from older QENVS images to new MAPT images which is where the former images were migrated. 

`rhqp/qenvs` -> `redhat-developer/mapt`

Fixes #196