### PR TITLE
chore: enable debugging of the goax pde2e job for faster response

### DIFF
--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -1,4 +1,5 @@
 name: Podman Desktop E2E with Podman installation
+run-name: Podman Desktop E2E with Podman installation ${{ inputs.debug == 'true' && '- Debug' || '' }}
 
 on:
   schedule:
@@ -25,6 +26,12 @@ on:
         description: 'Env. Variables passed into target machine'
         type: 'string'
         required: true
+      debug:
+        description: 'For debugging to restrict what is run'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 jobs:
   windows:
@@ -45,6 +52,8 @@ jobs:
           windows-featurepack: '23h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
+        - windows-version: ${{ (github.event.inputs.debug && github.event.inputs.debug == 'true') && '11' || 'N/A' }}
+          windows-featurepack: ${{ (github.event.inputs.debug && github.event.inputs.debug == 'true') && '23h2-ent' || 'N/A' }}
 
     steps:
     - name: Set the default env. variables
@@ -152,6 +161,7 @@ jobs:
         podman logs -f pd-e2e-windows
 
     - name: Run Podman Desktop Playwright E2E tests
+      if: ${{ !github.event.inputs.debug || github.event.inputs.debug == 'false' }}
       env:
         PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
       run: |


### PR DESCRIPTION
Adding new input parameter, `debug`, which is `false` by default. If it is set to true, only win 10 (22h2) will be triggered, the run name will get `- Debug` to distinguish between various runs and PD e2e tests wont get run.

I need faster response in order to debug the building of the production podman desktop bits with admin rights to avoid problems with `permission denied` during the build where deps changed and requires not some adjustments.