### PR TITLE
chore: add a workflow parameter to hyperv run virt. provider

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -44,6 +44,13 @@ on:
         description: 'Testing images versions, no spaces'
         type: 'string'
         required: true
+      podman_provider:
+        type: choice
+        description: 'Podman virtualization provider, default is wsl, alternative hyperv'
+        options:
+        - wsl
+        - hyperv
+        required: true
 
 jobs:
   windows:
@@ -76,10 +83,12 @@ jobs:
         DEFAULT_FORK: 'containers'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.1",PODMAN="v0.0.1",RUNNER="v0.0.1"'
       run: |
         echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
@@ -203,6 +212,7 @@ jobs:
                 -start ${{ github.event.inputs.podman_start }} \
                 -rootful ${{ matrix.rootful }} \
                 -userNetworking ${{ matrix.user-networking }} \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
                 -envVars ${{ github.event.inputs.env_vars }} \
                 -secretFile secrets.txt
         # check logs

--- a/.github/workflows/podman-desktop-e2e-nightly-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows.yaml
@@ -35,6 +35,13 @@ on:
         description: 'Testing images versions, no spaces'
         type: 'string'
         required: true
+      podman_provider:
+        type: choice
+        description: 'Podman virtualization provider, default is wsl, alternative hyperv'
+        options:
+        - wsl
+        - hyperv
+        required: true
 
 jobs:
   windows:
@@ -62,12 +69,14 @@ jobs:
         DEFAULT_FORK: 'containers'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
         DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.1",PODMAN="v0.0.1",RUNNER="v0.0.1"'
       run: |
         echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
@@ -189,6 +198,7 @@ jobs:
                 -initialize 1 \
                 -start 1 \
                 -rootful 1 \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
                 -envVars ${{ env.ENV_VARS }} \
                 -secretFile secrets.txt
         # check logs

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -37,6 +37,13 @@ on:
         description: 'Testing images versions, no spaces'
         type: 'string'
         required: true
+      podman_provider:
+        type: choice
+        description: 'Podman virtualization provider, default is wsl, alternative hyperv'
+        options:
+        - wsl
+        - hyperv
+        required: true
 
 jobs:
   windows:
@@ -66,12 +73,14 @@ jobs:
         DEFAULT_FORK: 'containers'
         DEFAULT_BRANCH: 'main'
         DEFAULT_NPM_TARGET: 'test:e2e'
+        DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.1",PODMAN="v0.0.1",RUNNER="v0.0.1"'
       run: |
         echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
         echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
+        echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "${{ env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
@@ -195,6 +204,7 @@ jobs:
                 -rootful ${{ env.PODMAN_ROOTFUL }} \
                 -start ${{ env.PODMAN_START }} \
                 -userNetworking ${{ env.PODMAN_NETWORKING }} \
+                -podmanProvider ${{ env.PODMAN_PROVIDER }} \
                 -envVars ${{ env.ENV_VARS }} \
                 -secretFile secrets.txt
         # check logs


### PR DESCRIPTION
fixes #142 

Add a parameter to the win-workflows to run hyperv as a virtualization provider to e2e tests. It is optional paramter, default is still wsl until we are sure the workflows are running fine.