### PR TITLE
Add timeout to desktop-e2e-test-job-windows.yaml

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -55,6 +55,7 @@ on:
 jobs:
   windows:
     name: ${{ matrix.windows-version }} - ${{ matrix.rootful == '0' && 'rootless' || 'rootful' }} ${{ matrix.user-networking == '1' && '- user mode networking enabled' || '' }}
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -54,6 +54,7 @@ on:
 jobs:
   windows:
     name: ${{ matrix.windows-version }} - Debug
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -180,7 +181,6 @@ jobs:
         podman logs -f pde2e-podman-run
 
     - name: Run Podman Desktop Playwright E2E tests
-      timeout-minutes: 60
       env:
         PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
       run: |

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -180,6 +180,7 @@ jobs:
         podman logs -f pde2e-podman-run
 
     - name: Run Podman Desktop Playwright E2E tests
+      timeout-minutes: 60
       env:
         PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
       run: |

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -43,6 +43,7 @@ on:
 
 jobs:
   windows:
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -43,6 +43,7 @@ on:
 
 jobs:
   windows:
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -47,6 +47,7 @@ on:
 
 jobs:
   windows:
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/podman-e2e-windows.yaml
+++ b/.github/workflows/podman-e2e-windows.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   windows:
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Adds a 60-minute timeout to the 'Run Podman Desktop Playwright E2E tests' step so that the workflow can't get stuck. From previous executions this step should last between 35 and 45 minutes, so it should be enough time to run on a normal execution. Fixes #225.