### PR TITLE
chore(ci): use repo variables for both scheduled and manual triggers

### DIFF
--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -103,7 +103,7 @@ jobs:
         if [ -n "${{ github.event.inputs.mapt_params }}" ]; then
           mapt_params="${{ github.event.inputs.mapt_params }}"
         else
-          mapt_params="IMAGE=${{ secrets.MAPT_IMAGE || vars.MAPT_IMAGE }};VERSION_TAG=${{ secrets.MAPT_VERSION_TAG || vars.MAPT_VERSION_TAG }};CPUS=${{ secrets.MAPT_CPUS || vars.MAPT_CPUS }};MEMORY=${{ secrets.MAPT_MEMORY || vars.MAPT_MEMORY }};EXCLUDED_REGIONS=\"${{ secrets.MAPT_EXCLUDED_REGIONS || vars.MAPT_EXCLUDED_REGIONS }}\""
+          mapt_params="IMAGE=${{ vars.MAPT_IMAGE }};VERSION_TAG=${{ vars.MAPT_VERSION_TAG }};CPUS=${{ vars.MAPT_CPUS }};MEMORY=${{ vars.MAPT_MEMORY }};EXCLUDED_REGIONS=\"${{ vars.MAPT_EXCLUDED_REGIONS }}\""
         fi
         echo "$mapt_params" | awk -F ';' '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "MAPT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 


### PR DESCRIPTION
This change always pulls values from repository variables(mapt related).
The description contains: 
 - Title
 - Format
 - Example

<img width="329" height="932" alt="Screenshot 2025-09-29 at 3 38 29 PM" src="https://github.com/user-attachments/assets/70c24027-2848-4c3a-ab8a-7c6624b97a15" />

Closes #478 

Tested:
Field empty(pull values from repository variables): https://github.com/podman-desktop/e2e/actions/runs/18098439077
Custom(override values from repository variables): https://github.com/podman-desktop/e2e/actions/runs/18098468382