### PR TITLE
test(e2e): update default values windows workflows

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -1,5 +1,5 @@
 name: PD E2E with Podman set
-run-name: PD E2E Tests with Podman ${{ inputs.podman_provider || 'wsl' }}
+run-name: PD E2E Tests with Podman ${{ inputs.podman_version || '(undefined version)' }} ${{ inputs.podman_provider == 'wsl' && 'WSL' || inputs.podman_provider == 'hyperv' && 'HyperV' || '(undefined provider)' }}
 
 on:
   workflow_dispatch:
@@ -14,9 +14,9 @@ on:
         description: 'npm target to run tests'
         type: string
         required: true
-      podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe'
-        description: 'podman latest version exe'
+      podman_version:
+        default: 'latest'
+        description: 'Podman version (use "latest" to auto-fetch latest release, or specify version like "v5.6.1")'
         type: string
         required: true
       podman_machine_options:
@@ -74,19 +74,25 @@ jobs:
           user-networking: 1
 
     steps:
+    - name: Fetch latest Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ github.event.inputs.podman_version || 'latest' }}
+        file_type: 'setup.exe'
+
     - name: Set the default env. variables
       env:
         DEFAULT_REPO_BRANCH: 'FORK=podman-desktop,BRANCH=main'
         DEFAULT_NPM_TARGET: 'test:e2e'
-        DEFAULT_PODMAN_REMOTE_URL: 'https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe'
         DEFAULT_PODMAN_MACHINE_OPTIONS: 'INIT=1,START=1'
         DEFAULT_PODMAN_PROVIDER: 'wsl'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
       run: |
         echo "${{ github.event.inputs.repo_branch || env.DEFAULT_REPO_BRANCH }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        # Set podman configuration variables directly from separate inputs
-        echo "PODMAN_REMOTE_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_PODMAN_REMOTE_URL }}" >> $GITHUB_ENV
+        # Set podman configuration variables from fetched version
+        echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_machine_options || env.DEFAULT_PODMAN_MACHINE_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
@@ -134,7 +140,7 @@ jobs:
       uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
+        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -1,5 +1,5 @@
 name: Test Workflow PD E2E with Podman
-run-name: Debugging Desktop E2E Tests with Podman ${{ contains(inputs.podman_options, 'WSL Provider') && 'wsl' || contains(inputs.podman_options, 'Hyper-V Provider') && 'hyperv' || '' }}
+run-name: Debugging PD E2E Tests with Podman ${{ contains(inputs.podman_options, 'PROVIDER=wsl') && 'WSL' || contains(inputs.podman_options, 'PROVIDER=hyperv') && 'HyperV' || '(undefined provider)' }}
 
 on:
   workflow_dispatch:
@@ -25,13 +25,10 @@ on:
         type: string
         required: true
       podman_options:
-        default: 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=wsl'
-        description: 'Podman configuration options with provider choice'
-        type: choice
+        default: 'PODMAN_VERSION=latest,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=wsl'
+        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest" or a version like "v5.6.2"; for PROVIDER use "wsl" or "hyperv" options.'
+        type: string
         required: true
-        options:
-          - 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=wsl'
-          - 'Hyper-V Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=hyperv'
       env_vars:
         default: 'TEST_PODMAN_MACHINE=true'
         description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along",RUN_KIND_TESTS=true'
@@ -65,26 +62,36 @@ jobs:
         windows-featurepack: ['22h2-ent']
 
     steps:
-    - name: Set the default env. variables
-      env:
-        DEFAULT_EXT_TESTS: '0'
-        DEFAULT_NPM_TARGET: 'test:e2e'
-        DEFAULT_PODMAN_OPTIONS: 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.2.5/podman-5.2.5-setup.exe,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=wsl'
-        DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-redhat-account-ext,FORK=redhat-developer,BRANCH=main'
-        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
-        DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
+    - name: Extract Podman version from options
+      id: extract-version
       run: |
-        echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
-        echo "EXT_TESTS=${{ github.event.inputs.ext_tests || env.DEFAULT_EXT_TESTS }}" >> $GITHUB_ENV
-        # Extract podman options, removing the descriptive prefix
-        PODMAN_OPTS="${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}"
-        echo "${PODMAN_OPTS#*: }" | awk -F ',' \
-         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
+        # Extract PODMAN_VERSION from the options string
+        PODMAN_OPTS="${{ github.event.inputs.podman_options }}"
+        PODMAN_VERSION=$(echo "${PODMAN_OPTS}" | grep -o 'PODMAN_VERSION=[^,]*' | cut -d'=' -f2)
+        echo "podman_version=${PODMAN_VERSION}" >> $GITHUB_OUTPUT
+        echo "Extracted Podman version: ${PODMAN_VERSION}"
+
+    - name: Fetch Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ steps.extract-version.outputs.podman_version }}
+        file_type: 'setup.exe'
+
+    - name: Set the environment variables
+      run: |
+        echo "NPM_TARGET=${{ github.event.inputs.npm_target }}" >> $GITHUB_ENV
+        echo "EXT_TESTS=${{ github.event.inputs.ext_tests }}" >> $GITHUB_ENV
+        # Extract podman options and set PODMAN_REMOTE_URL from fetch action
+        PODMAN_OPTS="${{ github.event.inputs.podman_options }}"
+        echo "${PODMAN_OPTS}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.pd_repo_options || env.DEFAULT_PD_REPO_OPTIONS }}" | awk -F ',' \
+        echo "${{ github.event.inputs.pd_repo_options }}" | awk -F ',' \
         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PD_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
+        echo "${{ github.event.inputs.images_version }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         
         # For mapt_params, use repo variables directly if input is empty
@@ -144,7 +151,7 @@ jobs:
         rootful: ${{ env.PODMAN_ROOTFUL }}
         user-networking: ${{ env.PODMAN_NETWORKING }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
-        env-vars: ${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}
+        env-vars: ${{ github.event.inputs.env_vars }}
 
     - name: Destroy instance
       if: always()

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -1,5 +1,5 @@
 name: PD k8s E2E with Podman Latest
-run-name: PD E2E Podman Latest Kubernetes
+run-name: PD E2E Podman ${{ inputs.podman_version || 'latest' }} Kubernetes
 
 on:
   schedule:
@@ -21,9 +21,9 @@ on:
         description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along"'
         type: 'string'
         required: true
-      podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe'
-        description: 'podman latest version exe'
+      podman_version:
+        default: 'latest'
+        description: 'Podman version (use "latest" to auto-fetch latest release, or specify version like "v5.6.1")'
         type: string
         required: true
       images_version:
@@ -75,13 +75,18 @@ jobs:
         echo "Default Podman Version from Podman Desktop: ${version}"
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
 
+    - name: Fetch latest Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ github.event.inputs.podman_version || 'latest' }}
+        file_type: 'setup.exe'
+
     - name: Set the default env. variables
       env:
         DEFAULT_REPO_BRANCH: 'FORK=podman-desktop,BRANCH=main'
         DEFAULT_NPM_TARGET: 'test:e2e:k8s'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=false'
-        DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.1' }}"
-        DEFAULT_URL: 'https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-$DEFAULT_VERSION-setup.exe'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
       run: |
         echo "${{ github.event.inputs.repo_branch || env.DEFAULT_REPO_BRANCH }}" | awk -F ',' \
@@ -89,7 +94,7 @@ jobs:
         echo "PODMAN_PROVIDER=${{ matrix.podman-provider }}" >> $GITHUB_ENV
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
-        echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
+        echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -1,5 +1,5 @@
 name: PD Podman-Remote E2E Nightly
-run-name: PD E2E Podman Remote Production mode
+run-name: PD E2E Podman Remote ${{ inputs.podman_version || '(undefined version)' }} ${{ inputs.podman_provider == 'wsl' && 'WSL' || inputs.podman_provider == 'hyperv' && 'HyperV' || '(undefined provider)' }} Production mode
 
 on:
   schedule:
@@ -16,9 +16,9 @@ on:
         description: 'npm target to run tests'
         type: string
         required: true
-      podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.4.0/podman-5.4.0-setup.exe'
-        description: 'podman latest released version exe'
+      podman_version:
+        default: 'latest'
+        description: 'Podman version (use "latest" to auto-fetch latest release, or specify version like "v5.6.1")'
         type: string
         required: true
       podman_desktop_url:
@@ -102,6 +102,13 @@ jobs:
         echo "Podman Desktop testing prerelease url: ${url}"
         echo "DEFAULT_PD_URL=${url}" >> $GITHUB_ENV
 
+    - name: Fetch latest Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ github.event.inputs.podman_version || 'latest' }}
+        file_type: 'setup.exe'
+
     - name: Set the default env. variables
       env:
         DEFAULT_NPM_TARGET: 'test:e2e:remote:run'
@@ -109,13 +116,11 @@ jobs:
         DEFAULT_PODMAN_OPTIONS: 'INIT=0,START=0,ROOTFUL=0,NETWORKING=0'
         DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
         DEFAULT_ENV_VARS: 'ELECTRON_ENABLE_INSPECT=true'
-        DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.4.0' }}"
-        DEFAULT_URL: 'https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-$DEFAULT_VERSION-setup.exe'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
       run: |
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
-        echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
+        echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
         echo "PD_URL=${{ github.event.inputs.podman_desktop_url || env.DEFAULT_PD_URL }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \

--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -1,5 +1,5 @@
 name: PD UI Stress Tests (Linux)
-run-name: PD E2E UI Stress Test
+run-name: PD E2E UI Stress Test (Linux) with Native Podman
 
 on:
   schedule:

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -1,5 +1,5 @@
 name: PD UI Stress Tests Windows
-run-name: PD E2E UI Stress Test
+run-name: PD E2E UI Stress Test (Windows) with Podman ${{ inputs.podman_provider == 'wsl' && 'WSL' || inputs.podman_provider == 'hyperv' && 'HyperV' || '(undefined provider)' }}
 
 on:
   schedule:
@@ -16,9 +16,9 @@ on:
         description: 'npm target to run tests'
         type: string
         required: true
-      podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.4.0/podman-5.4.0-setup.exe'
-        description: 'podman latest released version exe'
+      podman_version:
+        default: 'latest'
+        description: 'Podman version (use "latest" to auto-fetch latest release, or specify version like "v5.6.1")'
         type: string
         required: true
       podman_options:
@@ -80,6 +80,13 @@ jobs:
         windows-featurepack: ['24h2-ent']
 
     steps:
+    - name: Fetch latest Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ github.event.inputs.podman_version || 'latest' }}
+        file_type: 'setup.exe'
+
     - name: Set the default env. variables
       env:
         DEFAULT_NPM_TARGET: 'test:e2e:ui-stress'
@@ -89,12 +96,11 @@ jobs:
         DEFAULT_HOST_PARAMS: 'CPUS="8",MEMORY="16"'
         DEFAULT_IMAGE_SIZE: 'tiny'
         DEFAULT_ENV_VARS: 'ELECTRON_ENABLE_INSPECT=true,OBJECT_NUM=100,KEEP_VIDEOS_ON_PASS=true,KEEP_TRACES_ON_PASS=true'
-        DEFAULT_URL: 'https://api.cirrus-ci.com/v1/artifact/github/containers/podman/Artifacts/binary/podman-remote-release-windows_amd64.zip'
         DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
       run: |
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
-        echo "PODMAN_URL=${{ github.event.inputs.podman_remote_url || env.DEFAULT_URL }}" >> $GITHUB_ENV
+        echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }},IMAGE_SIZE=${{ github.event.inputs.image_size || env.DEFAULT_IMAGE_SIZE}}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.host_params || env.DEFAULT_HOST_PARAMS }}" | awk -F ',' \
         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "HOST_PARAMS_"kv[1]"="kv[2]}}' >> $GITHUB_ENV

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -1,5 +1,5 @@
 name: PD E2E Install & Run
-run-name: PD E2E with Podman installation ${{ inputs.podman_provider != '' && inputs.podman_provider || 'WSL' }} ${{ inputs.debug == 'true' && '- Debug' || '' }}
+run-name: PD E2E with Podman installation ${{ inputs.podman_provider == 'wsl' && 'WSL' || inputs.podman_provider == 'hyperv' && 'HyperV' || '(undefined provider)' }} ${{ inputs.debug == 'true' && '- Debug' || '' }}
 
 on:
   schedule:

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -1,5 +1,5 @@
 name: Debug E2E Testing Pre-Releases
-run-name: Debugging Nightly Podman Desktop E2E Tests
+run-name: Debugging Nightly PD E2E Tests with Podman ${{ contains(inputs.podman_options, 'PROVIDER=wsl') && 'WSL' || contains(inputs.podman_options, 'PROVIDER=hyperv') && 'HyperV' || '(undefined provider)' }}
 
 on:
   workflow_dispatch:
@@ -26,13 +26,10 @@ on:
         type: string
         required: true
       podman_options:
-        default: 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe,DESKTOP_URL=https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe,PROVIDER=wsl,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
-        description: 'Podman configuration options with provider choice'
-        type: choice
+        default: 'PODMAN_VERSION=latest,DESKTOP_URL=latest,PROVIDER=wsl,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
+        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest" or a version like "v5.6.2";for DESKTOP_URL use "latest" or a URL for a x64.exe artifact from https://github.com/podman-desktop/testing-prereleases/tags; for PROVIDER use "wsl" or "hyperv" options.'
+        type: string
         required: true
-        options:
-          - 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe,DESKTOP_URL=https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe,PROVIDER=wsl,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
-          - 'Hyper-V Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe,DESKTOP_URL=https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe,PROVIDER=hyperv,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
       env_vars:
         default: 'TEST_PODMAN_MACHINE=true'
         description: 'Env. Variables passed into target machine, ie: VAR1=xxx,VAR2=true,VAR3=15,VAR4="Pass me along"'
@@ -65,28 +62,63 @@ jobs:
         windows-featurepack: ['24h2-ent']
 
     steps:
-    - name: Set the default env. variables
-      env:
-        DEFAULT_CREATE_MACHINE: true
-        DEFAULT_NPM_TARGET: 'test:e2e'
-        DEFAULT_PODMAN_OPTIONS: 'WSL Provider: REMOTE_URL=https://github.com/containers/podman/releases/download/v5.3.1/podman-5.3.1-setup.exe,DESKTOP_URL=https://github.com/podman-desktop/testing-prereleases/releases/download/v1.16.0-202501090247-57bf7774e68/podman-desktop-1.16.0-202501090247-57bf7774e68-x64.exe,PROVIDER=wsl,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
-        DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-extension-ai-lab,FORK=containers,BRANCH=main,TESTS=0'
-        DEFAULT_PD_REPO_OPTIONS: 'REPO=podman-desktop,FORK=podman-desktop,BRANCH=main'
-        DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=true'
-        DEFAULT_IMAGES_VERSIONS: 'BUILDER="v0.0.3",PODMAN="v0.0.3",RUNNER="v0.0.3"'
+    - name: Extract Podman version from options
+      id: extract-version
       run: |
-        echo "CREATE_MACHINE=${{ github.event.inputs.create_machine || env.DEFAULT_CREATE_MACHINE }}" >> $GITHUB_ENV  
-        echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
-        echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
-        # Extract podman options, removing the descriptive prefix
-        PODMAN_OPTS="${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}"
-        echo "${PODMAN_OPTS#*: }" | awk -F ',' \
-         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.ext_repo_options || env.DEFAULT_EXT_REPO_OPTIONS }}" | awk -F ',' \
+        # Extract PODMAN_VERSION from the options string
+        PODMAN_OPTS="${{ github.event.inputs.podman_options }}"
+        PODMAN_VERSION=$(echo "${PODMAN_OPTS}" | grep -o 'PODMAN_VERSION=[^,]*' | cut -d'=' -f2)
+        echo "podman_version=${PODMAN_VERSION}" >> $GITHUB_OUTPUT
+        echo "Extracted Podman version: ${PODMAN_VERSION}"
+
+    - name: Fetch Podman version
+      id: fetch-podman
+      uses: podman-desktop/e2e/.github/actions/fetch-latest-podman-version@main
+      with:
+        version_input: ${{ steps.extract-version.outputs.podman_version }}
+        file_type: 'setup.exe'
+
+    - name: Extract Podman Desktop version from options and set it
+      id: extract-podman-desktop-url
+      run: |
+        # Extract DESKTOP_URL from the options string
+        PODMAN_OPTS="${{ github.event.inputs.podman_options }}"
+        DESKTOP_URL=$(echo "${PODMAN_OPTS}" | grep -o 'DESKTOP_URL=[^,]*' | cut -d'=' -f2)
+
+        if [ "${DESKTOP_URL}" = "latest" ]; then
+          # Fetch latest Podman Desktop x64.exe artifact url from testing-prereleases repository
+          DESKTOP_URL=$(curl -s https://api.github.com/repos/podman-desktop/testing-prereleases/releases | jq -r '.[0].assets[] | select(.name? | endswith("-x64.exe")) | select(.name | contains("setup") | not) | .browser_download_url')
+          echo "Latest Podman Desktop version from testing-prereleases repository: ${DESKTOP_URL}"
+        fi
+
+        echo "podman_desktop_url=${DESKTOP_URL}" >> $GITHUB_OUTPUT
+        echo "Extracted Podman Desktop URL: ${DESKTOP_URL}"
+
+        # Validate the URL
+        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -I "$DESKTOP_URL")
+        if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "302" ]; then
+          echo "Error: Download file not found (HTTP $HTTP_CODE)"
+          echo "URL: $DESKTOP_URL"
+          echo "This may indicate the version doesn't exist or the file type isn't available for this version"
+          exit 1
+        fi
+
+    - name: Set the env. variables
+      run: |
+        echo "CREATE_MACHINE=${{ github.event.inputs.create_machine }}" >> $GITHUB_ENV
+        echo "NPM_TARGET=${{ github.event.inputs.npm_target }}" >> $GITHUB_ENV
+        echo "ENV_VARS=${{ github.event.inputs.env_vars }}" >> $GITHUB_ENV
+        # Extract podman options and set PODMAN_REMOTE_URL from fetch action
+        PODMAN_OPTS="${{ github.event.inputs.podman_options }}"
+        echo "${PODMAN_OPTS}" | awk -F ',' \
+         '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION" && kv[1] != "DESKTOP_URL") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
+        echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_DESKTOP_URL=${{ steps.extract-podman-desktop-url.outputs.podman_desktop_url }}" >> $GITHUB_ENV
+        echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.pd_repo_options || env.DEFAULT_PD_REPO_OPTIONS }}" | awk -F ',' \
+        echo "${{ github.event.inputs.pd_repo_options }}" | awk -F ',' \
         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PD_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
-        echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
+        echo "${{ github.event.inputs.images_version }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
         # For mapt_params, use repo variables directly if input is empty


### PR DESCRIPTION
Completes https://github.com/podman-desktop/e2e/issues/222 by adding the `fetch-latest-podman-version` action to the corresponding workflows, like in `podman-desktop-e2e-nightly-windows-hyperv.yaml`

There are a couple of workflows ([desktop-e2e-test-job-windows.yaml](https://github.com/podman-desktop/e2e/blob/main/.github/workflows/desktop-e2e-test-job-windows.yaml) and [prerelease-desktop-e2e-debug-job-windows.yaml](https://github.com/podman-desktop/e2e/blob/main/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml)) where I just updated the hardcoded values to the latest available, but only because they have the podman version as an input concatenated with several podman options, and it would be a significant change. In my opinion the input should be transformed into a text field rather than a dropdown, like in other inputs of the same workflow, but instead of specifying the podman url you put the version and we pass the value to the action. With the current way you can't change the version, or anything other than wsl/hyperv provider:

<img width="558" height="286" alt="image" src="https://github.com/user-attachments/assets/8f3cf91b-b6df-498e-9739-8ba175c6184e" />

I figured that this was done like this for a reason, so I wanted to ask for feedback on how to proceed