### PR TITLE
chore(e2e): add github token to release fetch

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -76,10 +76,11 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -73,10 +73,11 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the environment variables
       run: |

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -71,10 +71,11 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -78,10 +78,11 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -72,10 +72,11 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -98,10 +98,11 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -82,10 +82,11 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set the default env. variables
       env:

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -73,10 +73,11 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@e4b1fa48c45110617d0ae3a995b81428f4234d96
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'setup.exe'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract Podman Desktop version from options and set it
       id: extract-podman-desktop-url


### PR DESCRIPTION
Closes https://github.com/podman-desktop/e2e/issues/494

Tested the changes on my fork (https://github.com/danivilla9/podman-desktop-e2e/actions/runs/19635297619/job/56224411470), seems to pass the parameter to the action successfully:
```
Run redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b757b792b67ec663765a4f2ca36226e12b2f4cd
Run INPUT_VERSION="latest"
Input version: latest
Architecture: amd64
File type: setup.exe
GitHub Token: ***
Fetching latest Podman release...
Using GITHUB_TOKEN for authenticated API request.
Latest Podman version: v5.7.0
Download URL: https://github.com/containers/podman/releases/download/v5.7.0/podman-5.7.0-setup.exe
Validating download URL...
Download URL validated successfully
```