### PR TITLE
chore: add script that fixes wsl dns issue

### DIFF
--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -138,6 +138,7 @@ jobs:
         podman-provider: ${{ env.PODMAN_PROVIDER }}
         env-vars: ${{ env.ENV_VARS }}
         ci-bot-token: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
+        script-path: 'wsl_dns_update.ps1'
 
     - name: Create json file with workflow run attributes
       if: always()


### PR DESCRIPTION
Calls the newly added script that sets up the dns configuration in wsl machines that are currently failing

Related PRs:
- https://github.com/odockal/pde2e-runner/pull/33
- https://github.com/podman-desktop/podman-desktop/pull/15192

Related issue:
- https://github.com/podman-desktop/podman-desktop/issues/14825