### PR TITLE
chore: update windows featurepacks

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -62,12 +62,12 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '23h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         rootful: [0, 1]
         user-networking: ${{ inputs.podman_provider == 'hyperv' && fromJSON('[0]') || fromJSON('[0, 1]') }}
         exclude:
         - windows-version: '10'
-          windows-featurepack: '23h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
         - rootful: 0

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -60,11 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '24h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         podman-provider: ['wsl', 'hyperv']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '24h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -62,10 +62,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '23h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '23h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -62,10 +62,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '23h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         exclude:
           - windows-version: '10'
-            windows-featurepack: '23h2-ent'
+            windows-featurepack: '25h2-ent'
           - windows-version: '11'
             windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['11']
-        windows-featurepack: ['24h2-ent']
+        windows-featurepack: ['25h2-ent']
 
     steps:
     - name: Get Latest Podman Desktop testing prerelease


### PR DESCRIPTION
Changes the current feature packs used in windows 11 jobs to the most recent versions, given that they are outdated.

A discussion could be had for if we want to havethe second latest too, 24h2-ent.

Closes https://github.com/podman-desktop/e2e/issues/528