### PR TITLE
fix: fix property name deafult -> default in pd-e2e-goax tekton task

### DIFF
--- a/tkn/task.yaml
+++ b/tkn/task.yaml
@@ -61,7 +61,7 @@ spec:
   # Control params
   - name: target-cleanup
     description: 'this param controls if folder on target host will be removed. Defaults true'
-    deafult: 'true'
+    default: 'true'
 
   results:
   - name: duration


### PR DESCRIPTION
Fixes: https://github.com/containers/podman-desktop-internal/issues/927