### PR TITLE
fix(ci): update podman org in TF install script

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -82,7 +82,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'

--- a/plans/scripts/install-podman.sh
+++ b/plans/scripts/install-podman.sh
@@ -20,7 +20,7 @@ if [[ "$PODMAN_VERSION" == "nightly" ]]; then
 else
     # For "latest" or specific version, fetch version if needed and install from RPM
     if [[ "$PODMAN_VERSION" == "latest" ]]; then
-        PODMAN_VERSION="$(curl -s https://api.github.com/repos/containers/podman/releases | jq -r '.[] | select(.prerelease == false) | .tag_name' | head -n1 | sed 's/^v//')"
+        PODMAN_VERSION="$(curl -sL https://api.github.com/repos/podman-container-tools/podman/releases | jq -r '.[] | select(.prerelease == false) | .tag_name' | head -n1 | sed 's/^v//')"
     fi
     CUSTOM_PODMAN_URL="https://kojipkgs.fedoraproject.org//packages/podman/${PODMAN_VERSION}/1.${COMPOSE_VERSION}/${ARCH}/podman-${PODMAN_VERSION}-1.${COMPOSE_VERSION}.${ARCH}.rpm"
     curl -Lo podman.rpm "$CUSTOM_PODMAN_URL"


### PR DESCRIPTION
## Summary
- Update GitHub API URL in `plans/scripts/install-podman.sh` from `containers/podman` to `podman-container-tools/podman` to reflect the Podman organization change

Related: podman-desktop/podman-desktop#17679

## Test plan
- [ ] Verify Testing Farm CI runs resolve the correct latest Podman version from the new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)