### PR TITLE
chore(ci): update windows featurepack to 25h2 and 26h1

### DIFF
--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -62,12 +62,12 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '25h2-ent']
+        windows-featurepack: ['22h2-ent', '26h1-ent']
         rootful: [0, 1]
         user-networking: ${{ inputs.podman_provider == 'hyperv' && fromJSON('[0]') || fromJSON('[0, 1]') }}
         exclude:
         - windows-version: '10'
-          windows-featurepack: '25h2-ent'
+          windows-featurepack: '26h1-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
         - rootful: 0

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -60,11 +60,11 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '25h2-ent']
+        windows-featurepack: ['22h2-ent', '26h1-ent']
         podman-provider: ['wsl', 'hyperv']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '25h2-ent'
+          windows-featurepack: '26h1-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -62,10 +62,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '25h2-ent']
+        windows-featurepack: ['22h2-ent', '26h1-ent']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '25h2-ent'
+          windows-featurepack: '26h1-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -62,10 +62,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '25h2-ent']
+        windows-featurepack: ['22h2-ent', '26h1-ent']
         exclude:
           - windows-version: '10'
-            windows-featurepack: '25h2-ent'
+            windows-featurepack: '26h1-ent'
           - windows-version: '11'
             windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['11']
-        windows-featurepack: ['24h2-ent']
+        windows-featurepack: ['26h1-ent']
 
     steps:
     - name: Fetch latest Podman version

--- a/.github/workflows/podman-desktop-e2e-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-windows.yaml
@@ -59,14 +59,14 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '23h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '23h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
         - windows-version: ${{ (github.event.inputs.debug && github.event.inputs.debug == 'true') && '11' || 'N/A' }}
-          windows-featurepack: ${{ (github.event.inputs.debug && github.event.inputs.debug == 'true') && '23h2-ent' || 'N/A' }}
+          windows-featurepack: ${{ (github.event.inputs.debug && github.event.inputs.debug == 'true') && '25h2-ent' || 'N/A' }}
 
     steps:
     - name: Set the default env. variables

--- a/.github/workflows/podman-e2e-windows.yaml
+++ b/.github/workflows/podman-e2e-windows.yaml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['10','11']
-        windows-featurepack: ['22h2-ent', '24h2-ent']
+        windows-featurepack: ['22h2-ent', '25h2-ent']
         exclude:
         - windows-version: '10'
-          windows-featurepack: '24h2-ent'
+          windows-featurepack: '25h2-ent'
         - windows-version: '11'
           windows-featurepack: '22h2-ent'
 

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         windows-version: ['11']
-        windows-featurepack: ['24h2-ent']
+        windows-featurepack: ['25h2-ent']
 
     steps:
     - name: Extract Podman version from options


### PR DESCRIPTION
Standardize all Windows CI workflows to use 25h2-ent featurepack and 26h1 featurepack, removing outdated 22h2-ent, 23h2-ent, and 24h2-ent entries along with their version-specific exclusion rules.

Closes https://github.com/podman-desktop/e2e/issues/535