### PR TITLE
fix(ci): use default node version in TF workflow

### DIFF
--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "FORK=${{ github.event.inputs.fork || env.DEFAULT_FORK }}" >> $GITHUB_ENV
           echo "BRANCH=${{ github.event.inputs.branch || env.DEFAULT_BRANCH }}" >> $GITHUB_ENV
           echo "PODMAN_VERSION=${{ github.event.inputs.podman_version || env.DEFAULT_PODMAN_VERSION }}" >> $GITHUB_ENV
-          echo "NODE_VERSION=${{ vars.NODE_VERSION || env.DEFAULT_NODE_VERSION }}" >> $GITHUB_ENV
+          echo "NODE_VERSION=${{ env.DEFAULT_NODE_VERSION }}" >> $GITHUB_ENV
 
       - name: Run Podman Desktop Playwright E2E tests on Testing Farm CI
         id: run-e2e-tf


### PR DESCRIPTION
## Summary
- Removed `vars.NODE_VERSION` repo variable lookup from the TF workflow, using `DEFAULT_NODE_VERSION` (`v24.15.0`) directly instead
- The repo-level variable was set to an outdated version (`v24.11.1`), overriding the workflow default and causing the wrong Node.js version to be installed on Testing Farm runners

## Test plan
- [ ] Trigger a TF workflow run and verify Node.js `v24.15.0` is installed on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)