### PR TITLE
fix(windows): export KAIDEN_BINARY when installing Kaiden via -pdUrl

### DIFF
--- a/pde2e-image/README.md
+++ b/pde2e-image/README.md
@@ -291,6 +291,9 @@ podman logs -f pde2e-image-run
 
 ### Kaiden Windows Example without Podman Installation
 
+When `-appName Kaiden` (or `-repo kaiden`) is used, the runner keeps `Kaiden.exe` at
+`%LOCALAPPDATA%\Programs\kaiden\` and exports `KAIDEN_BINARY` for Kaiden's Playwright CDP harness.
+
 ```sh
 podman run --rm -d --name pde2e-image-run \
   -e TARGET_HOST=$(cat host-win) \

--- a/pde2e-image/common/windows/common.ps1
+++ b/pde2e-image/common/windows/common.ps1
@@ -74,6 +74,19 @@ function Load-Variables() {
         $global:scriptEnvVars += "PODMAN_DESKTOP_ARGS"
         $global:envVarDefs += "PODMAN_DESKTOP_ARGS=$workingDir\$repo"
     }
+
+    # Kaiden Playwright tests read KAIDEN_BINARY (not PODMAN_DESKTOP_BINARY)
+    $isKaidenApp = ($appName -eq 'Kaiden') -or ($repo -eq 'kaiden')
+    $binaryForKaiden = $kaidenBinary
+    if (-not $binaryForKaiden -and $podmanDesktopBinary -and $isKaidenApp) {
+        $binaryForKaiden = $podmanDesktopBinary
+    }
+    if ($binaryForKaiden -and $isKaidenApp) {
+        Set-Item -Path "env:KAIDEN_BINARY" -Value "$binaryForKaiden"
+        $global:scriptEnvVars += "KAIDEN_BINARY"
+        $global:envVarDefs += "KAIDEN_BINARY=$binaryForKaiden"
+        Write-Host "Setting env. var.: KAIDEN_BINARY=$binaryForKaiden"
+    }
     # Check if the input string is not null or empty
     if (-not [string]::IsNullOrWhiteSpace($envVars)) {
         # Split the input using comma separator

--- a/pde2e-image/lib/windows/runner.ps1
+++ b/pde2e-image/lib/windows/runner.ps1
@@ -152,6 +152,8 @@ if (-not(Test-Path -Path $toolsInstallDir)) {
 
 # Installation of application
 $podmanDesktopBinary=""
+$kaidenBinary=""
+$isKaidenApp = ($appName -eq 'Kaiden') -or ($repo -eq 'kaiden')
 
 if ([string]::IsNullOrWhiteSpace($pdPath))
 {
@@ -179,9 +181,14 @@ if ([string]::IsNullOrWhiteSpace($pdPath))
             write-host "$appName is installed on expected path: $pdLocalAppData"
             if (Test-Path -Path $pdPath -PathType Leaf) {
                 write-host "$appName installation present..."
-                mv "$pdPath" "$pdLocalAppData\pd.exe"
-                write-host
-                $podmanDesktopBinary="$pdLocalAppData\pd.exe"
+                if ($isKaidenApp) {
+                    $kaidenBinary = $pdPath
+                    $podmanDesktopBinary = $pdPath
+                } else {
+                    mv "$pdPath" "$pdLocalAppData\pd.exe"
+                    write-host
+                    $podmanDesktopBinary="$pdLocalAppData\pd.exe"
+                }
             } else {
                 write-host "$appName binary is missing..."
                 ls $pdLocalAppData
@@ -191,11 +198,17 @@ if ([string]::IsNullOrWhiteSpace($pdPath))
             Download-App('pd.exe')
             write-host "Only a binary is available from url..."
             $podmanDesktopBinary="$workingDir\pd.exe"
+            if ($isKaidenApp) {
+                $kaidenBinary = $podmanDesktopBinary
+            }
         }
     }
 } else {
     # set application binary path
     $podmanDesktopBinary=$pdPath
+    if ($isKaidenApp) {
+        $kaidenBinary = $pdPath
+    }
 }
 
 # load variables


### PR DESCRIPTION
Kaiden MAPT e2e runs install via -pdUrl but Playwright needs KAIDEN_BINARY, not PODMAN_DESKTOP_BINARY. This sets that env var after install and keeps Kaiden.exe instead of renaming it.