### PR TITLE
chore(ci): update sha for podman-install action

### DIFF
--- a/.github/actions/download-podman-nightly/action.yml
+++ b/.github/actions/download-podman-nightly/action.yml
@@ -41,8 +41,13 @@ inputs:
     description: 'The tag for the builder-image to be used for downloading Podman.'
     required: true
   podman-download-url:
-    description: 'The URL to download the Podman nightly build from.'
-    required: true
+    description: 'The URL to download the Podman build from.'
+    required: false
+    default: ''
+  podman-local-installer:
+    description: 'Local MSI path on the runner for GitHub Actions nightly artifacts.'
+    required: false
+    default: ''
   podman-provider:
     description: 'The Podman provider to be used.'
     required: false
@@ -51,9 +56,81 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Download Podman nightly, do not initialize'
+    - name: 'Install Podman from local nightly artifact'
+      if: inputs.podman-local-installer != ''
       shell: bash
       run: |
+        set -euo pipefail
+
+        TARGET_HOST="$(cat host)"
+        TARGET_USER="$(cat username)"
+        KEY_PATH="id_rsa"
+        TARGET_FOLDER="${{ inputs.target-folder }}"
+        RESULTS_FOLDER="${{ inputs.results-folder }}"
+        LOCAL_INSTALLER="${{ inputs.podman-local-installer }}"
+
+        if [ ! -f "$LOCAL_INSTALLER" ]; then
+          echo "Error: Local installer not found at $LOCAL_INSTALLER"
+          exit 1
+        fi
+
+        chmod 600 "$KEY_PATH"
+        REMOTE_TOOLS='tools'
+        REMOTE_MSI="${REMOTE_TOOLS}/podman.msi"
+        REMOTE_SCRIPT="${RESULTS_FOLDER}/scripts/install-local-podman.ps1"
+
+        ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
+          "powershell -NoProfile -Command \"New-Item -ItemType Directory -Force -Path '${REMOTE_TOOLS}', '${TARGET_FOLDER}/${RESULTS_FOLDER}/scripts' | Out-Null\""
+
+        scp -i "$KEY_PATH" -o StrictHostKeyChecking=no "$LOCAL_INSTALLER" \
+          "${TARGET_USER}@${TARGET_HOST}:${REMOTE_MSI}"
+
+        cat > install-local-podman.ps1 <<EOF
+        \$resultsFolder = Join-Path (Get-Location) '${{ inputs.results-folder }}'
+        \$toolsInstallDir = Join-Path \$env:USERPROFILE 'tools'
+        \$msiPath = Join-Path \$toolsInstallDir 'podman.msi'
+        New-Item -ItemType Directory -Force -Path \$resultsFolder | Out-Null
+        \$msiLogFile = Join-Path \$resultsFolder 'podman-msi.log'
+
+        Write-Host "Installing Podman MSI from \$msiPath"
+        \$process = Start-Process msiexec.exe -ArgumentList '/package', \$msiPath, '/quiet', '/l*v', \$msiLogFile -PassThru -Wait
+        Write-Host "Install process exit code: \$(\$process.ExitCode)"
+        if (\$process.ExitCode -ne 0) {
+          if (Test-Path \$msiLogFile) {
+            Get-Content \$msiLogFile | ForEach-Object { Write-Host \$_ }
+          }
+          throw "Podman MSI installation failed with exit code: \$(\$process.ExitCode)"
+        }
+
+        \$podmanPath = Join-Path \$env:LOCALAPPDATA 'Programs/Podman/'
+        if (-not (Test-Path \$podmanPath)) {
+          throw "Expected Podman path \$podmanPath does not exist"
+        }
+
+        \$env:Path += ";\$podmanPath"
+        \$currentUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if (-not \$currentUserPath.Contains(\$podmanPath)) {
+          [Environment]::SetEnvironmentVariable('Path', (\$currentUserPath + ';' + \$podmanPath), 'User')
+        }
+
+        podman version
+        EOF
+
+        scp -i "$KEY_PATH" -o StrictHostKeyChecking=no install-local-podman.ps1 \
+          "${TARGET_USER}@${TARGET_HOST}:${TARGET_FOLDER}/${REMOTE_SCRIPT}"
+
+        ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
+          "cd '${TARGET_FOLDER}' && powershell -NoProfile -ExecutionPolicy Bypass -File '${REMOTE_SCRIPT}'"
+
+    - name: 'Download Podman nightly, do not initialize'
+      if: inputs.podman-local-installer == ''
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.podman-download-url }}" ]; then
+          echo "Error: podman-download-url is required when podman-local-installer is not provided"
+          exit 1
+        fi
+
         CMD="podman run --rm -d --name pde2e-podman-run \
           -e TARGET_HOST=$(cat host) \
           -e TARGET_HOST_USERNAME=$(cat username) \
@@ -85,4 +162,37 @@ runs:
         eval "$CMD"
 
         # Check logs
+        podman logs -f pde2e-podman-run
+
+    - name: 'Configure Podman provider after local install'
+      if: inputs.podman-local-installer != ''
+      shell: bash
+      run: |
+        CMD="podman run --rm -d --name pde2e-podman-run \
+          -e TARGET_HOST=$(cat host) \
+          -e TARGET_HOST_USERNAME=$(cat username) \
+          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
+          -e TARGET_FOLDER=${{ inputs.target-folder }} \
+          -e TARGET_CLEANUP=${{ inputs.target-cleanup }} \
+          -e TARGET_RESULTS=${{ inputs.results-folder }} \
+          -e OUTPUT_FOLDER=/data \
+          -e DEBUG=${{ inputs.debug-mode }} \
+          -v $PWD:/data:z \
+          ${{ inputs.builder-image }}:${{ inputs.podman-image-tag }}-windows \
+            pd-e2e/podman.ps1 \
+              -downloadUrl https://example.invalid/podman.msi \
+              -targetFolder ${{ inputs.target-folder }} \
+              -resultsFolder ${{ inputs.results-folder }} \
+              -initialize 0 \
+              -rootful 0 \
+              -start 0"
+
+        if [[ -n "${{ inputs.podman-provider }}" ]]; then
+          CMD+=" -podmanProvider ${{ inputs.podman-provider }}"
+        else
+          CMD+=" -installWSL 0"
+        fi
+
+        echo "$CMD"
+        eval "$CMD"
         podman logs -f pde2e-podman-run

--- a/.github/actions/download-podman-nightly/action.yml
+++ b/.github/actions/download-podman-nightly/action.yml
@@ -41,11 +41,10 @@ inputs:
     description: 'The tag for the builder-image to be used for downloading Podman.'
     required: true
   podman-download-url:
-    description: 'The URL to download the Podman build from.'
-    required: false
-    default: ''
-  podman-local-installer:
-    description: 'Local MSI path on the runner for GitHub Actions nightly artifacts.'
+    description: 'The URL to download the Podman build from (release asset or Actions artifact archive_download_url).'
+    required: true
+  github-token:
+    description: 'GitHub token required to download Actions artifact archive URLs (nightly/main).'
     required: false
     default: ''
   podman-provider:
@@ -56,9 +55,65 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Install Podman from local nightly artifact'
-      if: inputs.podman-local-installer != ''
+    - name: 'Resolve authenticated Actions artifact to local MSI'
+      id: resolve-artifact
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        PODMAN_DOWNLOAD_URL: ${{ inputs.podman-download-url }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PODMAN_DOWNLOAD_URL}" ]; then
+          echo "Error: podman-download-url is required"
+          exit 1
+        fi
+
+        # Nightly/main from fetch-latest-podman-version-windows returns archive_download_url
+        # (…/actions/artifacts/<id>/zip). Download + unzip on the runner, then SCP the MSI.
+        if [[ "${PODMAN_DOWNLOAD_URL}" =~ /actions/artifacts/.+/zip ]]; then
+          if [ -z "${GITHUB_TOKEN}" ]; then
+            echo "Error: github-token is required to download GitHub Actions artifact archives"
+            exit 1
+          fi
+
+          ARTIFACT_DIR="${RUNNER_TEMP:-/tmp}/podman-actions-artifact"
+          ZIP_PATH="${ARTIFACT_DIR}/podman-artifact.zip"
+          EXTRACT_DIR="${ARTIFACT_DIR}/extracted"
+          MSI_PATH="${ARTIFACT_DIR}/podman.msi"
+
+          rm -rf "${ARTIFACT_DIR}"
+          mkdir -p "${EXTRACT_DIR}"
+
+          echo "Downloading Actions artifact archive…"
+          curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -o "${ZIP_PATH}" \
+            "${PODMAN_DOWNLOAD_URL}"
+
+          unzip -qo "${ZIP_PATH}" -d "${EXTRACT_DIR}"
+          FOUND_MSI="$(find "${EXTRACT_DIR}" -type f -name '*.msi' | head -n1 || true)"
+          if [ -z "${FOUND_MSI}" ]; then
+            echo "Error: No MSI file found inside Actions artifact archive"
+            find "${EXTRACT_DIR}" -type f
+            exit 1
+          fi
+
+          cp -f "${FOUND_MSI}" "${MSI_PATH}"
+          echo "Resolved local MSI: ${MSI_PATH}"
+          echo "local_msi=${MSI_PATH}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "Using public/release download URL (no local MSI resolution)"
+          echo "local_msi=" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: 'Install Podman from local nightly artifact'
+      if: steps.resolve-artifact.outputs.local_msi != ''
+      shell: bash
+      env:
+        LOCAL_INSTALLER: ${{ steps.resolve-artifact.outputs.local_msi }}
       run: |
         set -euo pipefail
 
@@ -67,22 +122,21 @@ runs:
         KEY_PATH="id_rsa"
         TARGET_FOLDER="${{ inputs.target-folder }}"
         RESULTS_FOLDER="${{ inputs.results-folder }}"
-        LOCAL_INSTALLER="${{ inputs.podman-local-installer }}"
 
-        if [ ! -f "$LOCAL_INSTALLER" ]; then
-          echo "Error: Local installer not found at $LOCAL_INSTALLER"
+        if [ ! -f "${LOCAL_INSTALLER}" ]; then
+          echo "Error: Local installer not found at ${LOCAL_INSTALLER}"
           exit 1
         fi
 
-        chmod 600 "$KEY_PATH"
+        chmod 600 "${KEY_PATH}"
         REMOTE_TOOLS='tools'
         REMOTE_MSI="${REMOTE_TOOLS}/podman.msi"
         REMOTE_SCRIPT="${RESULTS_FOLDER}/scripts/install-local-podman.ps1"
 
-        ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
+        ssh -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
           "powershell -NoProfile -Command \"New-Item -ItemType Directory -Force -Path '${REMOTE_TOOLS}', '${TARGET_FOLDER}/${RESULTS_FOLDER}/scripts' | Out-Null\""
 
-        scp -i "$KEY_PATH" -o StrictHostKeyChecking=no "$LOCAL_INSTALLER" \
+        scp -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${LOCAL_INSTALLER}" \
           "${TARGET_USER}@${TARGET_HOST}:${REMOTE_MSI}"
 
         cat > install-local-podman.ps1 <<EOF
@@ -118,20 +172,17 @@ runs:
         podman version
         EOF
 
-        scp -i "$KEY_PATH" -o StrictHostKeyChecking=no install-local-podman.ps1 \
+        scp -i "${KEY_PATH}" -o StrictHostKeyChecking=no install-local-podman.ps1 \
           "${TARGET_USER}@${TARGET_HOST}:${TARGET_FOLDER}/${REMOTE_SCRIPT}"
 
-        ssh -i "$KEY_PATH" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
+        ssh -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
           "cd '${TARGET_FOLDER}' && powershell -NoProfile -ExecutionPolicy Bypass -File '${REMOTE_SCRIPT}'"
 
-    - name: 'Download Podman nightly, do not initialize'
-      if: inputs.podman-local-installer == ''
+    - name: 'Download Podman from release URL, do not initialize'
+      if: steps.resolve-artifact.outputs.local_msi == ''
       shell: bash
       run: |
-        if [ -z "${{ inputs.podman-download-url }}" ]; then
-          echo "Error: podman-download-url is required when podman-local-installer is not provided"
-          exit 1
-        fi
+        set -euo pipefail
 
         CMD="podman run --rm -d --name pde2e-podman-run \
           -e TARGET_HOST=$(cat host) \
@@ -152,24 +203,24 @@ runs:
               -rootful 0 \
               -start 0"
 
-        # Add the provider or the default WSL install parameter
         if [[ -n "${{ inputs.podman-provider }}" ]]; then
           CMD+=" -podmanProvider ${{ inputs.podman-provider }}"
         else
           CMD+=" -installWSL 0"
         fi
 
-        # Execute the final command
         echo "$CMD"
         eval "$CMD"
-
-        # Check logs
         podman logs -f pde2e-podman-run
 
     - name: 'Configure Podman provider after local install'
-      if: inputs.podman-local-installer != ''
+      if: steps.resolve-artifact.outputs.local_msi != ''
       shell: bash
       run: |
+        set -euo pipefail
+
+        # Podman is already installed from the local MSI. Reuse podman.ps1 only to
+        # configure the provider / skip WSL install (download URL is unused).
         CMD="podman run --rm -d --name pde2e-podman-run \
           -e TARGET_HOST=$(cat host) \
           -e TARGET_HOST_USERNAME=$(cat username) \

--- a/.github/actions/download-podman-nightly/action.yml
+++ b/.github/actions/download-podman-nightly/action.yml
@@ -55,134 +55,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Resolve authenticated Actions artifact to local MSI'
-      id: resolve-artifact
+    - name: 'Download Podman nightly, do not initialize'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        PODMAN_DOWNLOAD_URL: ${{ inputs.podman-download-url }}
       run: |
         set -euo pipefail
 
-        if [ -z "${PODMAN_DOWNLOAD_URL}" ]; then
+        if [ -z "${{ inputs.podman-download-url }}" ]; then
           echo "Error: podman-download-url is required"
           exit 1
         fi
-
-        # Nightly/main from fetch-latest-podman-version-windows returns archive_download_url
-        # (…/actions/artifacts/<id>/zip). Download + unzip on the runner, then SCP the MSI.
-        if [[ "${PODMAN_DOWNLOAD_URL}" =~ /actions/artifacts/.+/zip ]]; then
-          if [ -z "${GITHUB_TOKEN}" ]; then
-            echo "Error: github-token is required to download GitHub Actions artifact archives"
-            exit 1
-          fi
-
-          ARTIFACT_DIR="${RUNNER_TEMP:-/tmp}/podman-actions-artifact"
-          ZIP_PATH="${ARTIFACT_DIR}/podman-artifact.zip"
-          EXTRACT_DIR="${ARTIFACT_DIR}/extracted"
-          MSI_PATH="${ARTIFACT_DIR}/podman.msi"
-
-          rm -rf "${ARTIFACT_DIR}"
-          mkdir -p "${EXTRACT_DIR}"
-
-          echo "Downloading Actions artifact archive…"
-          curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -o "${ZIP_PATH}" \
-            "${PODMAN_DOWNLOAD_URL}"
-
-          unzip -qo "${ZIP_PATH}" -d "${EXTRACT_DIR}"
-          FOUND_MSI="$(find "${EXTRACT_DIR}" -type f -name '*.msi' | head -n1 || true)"
-          if [ -z "${FOUND_MSI}" ]; then
-            echo "Error: No MSI file found inside Actions artifact archive"
-            find "${EXTRACT_DIR}" -type f
-            exit 1
-          fi
-
-          cp -f "${FOUND_MSI}" "${MSI_PATH}"
-          echo "Resolved local MSI: ${MSI_PATH}"
-          echo "local_msi=${MSI_PATH}" >> "${GITHUB_OUTPUT}"
-        else
-          echo "Using public/release download URL (no local MSI resolution)"
-          echo "local_msi=" >> "${GITHUB_OUTPUT}"
-        fi
-
-    - name: 'Install Podman from local nightly artifact'
-      if: steps.resolve-artifact.outputs.local_msi != ''
-      shell: bash
-      env:
-        LOCAL_INSTALLER: ${{ steps.resolve-artifact.outputs.local_msi }}
-      run: |
-        set -euo pipefail
-
-        TARGET_HOST="$(cat host)"
-        TARGET_USER="$(cat username)"
-        KEY_PATH="id_rsa"
-        TARGET_FOLDER="${{ inputs.target-folder }}"
-        RESULTS_FOLDER="${{ inputs.results-folder }}"
-
-        if [ ! -f "${LOCAL_INSTALLER}" ]; then
-          echo "Error: Local installer not found at ${LOCAL_INSTALLER}"
-          exit 1
-        fi
-
-        chmod 600 "${KEY_PATH}"
-        REMOTE_TOOLS='tools'
-        REMOTE_MSI="${REMOTE_TOOLS}/podman.msi"
-        REMOTE_SCRIPT="${RESULTS_FOLDER}/scripts/install-local-podman.ps1"
-
-        ssh -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
-          "powershell -NoProfile -Command \"New-Item -ItemType Directory -Force -Path '${REMOTE_TOOLS}', '${TARGET_FOLDER}/${RESULTS_FOLDER}/scripts' | Out-Null\""
-
-        scp -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${LOCAL_INSTALLER}" \
-          "${TARGET_USER}@${TARGET_HOST}:${REMOTE_MSI}"
-
-        cat > install-local-podman.ps1 <<EOF
-        \$resultsFolder = Join-Path (Get-Location) '${{ inputs.results-folder }}'
-        \$toolsInstallDir = Join-Path \$env:USERPROFILE 'tools'
-        \$msiPath = Join-Path \$toolsInstallDir 'podman.msi'
-        New-Item -ItemType Directory -Force -Path \$resultsFolder | Out-Null
-        \$msiLogFile = Join-Path \$resultsFolder 'podman-msi.log'
-
-        Write-Host "Installing Podman MSI from \$msiPath"
-        \$process = Start-Process msiexec.exe -ArgumentList '/package', \$msiPath, '/quiet', '/l*v', \$msiLogFile -PassThru -Wait
-        Write-Host "Install process exit code: \$(\$process.ExitCode)"
-        if (\$process.ExitCode -ne 0) {
-          if (Test-Path \$msiLogFile) {
-            Get-Content \$msiLogFile | ForEach-Object { Write-Host \$_ }
-          }
-          throw "Podman MSI installation failed with exit code: \$(\$process.ExitCode)"
-        }
-
-        \$podmanPath = Join-Path \$env:LOCALAPPDATA 'Programs/Podman/'
-        if (-not (Test-Path \$podmanPath)) {
-          throw "Expected Podman path \$podmanPath does not exist"
-        }
-
-        \$env:Path += ";\$podmanPath"
-        \$currentUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        if ([string]::IsNullOrWhiteSpace(\$currentUserPath)) {
-          [Environment]::SetEnvironmentVariable('Path', \$podmanPath, 'User')
-        } elseif (-not \$currentUserPath.Contains(\$podmanPath)) {
-          [Environment]::SetEnvironmentVariable('Path', (\$currentUserPath + ';' + \$podmanPath), 'User')
-        }
-
-        podman version
-        EOF
-
-        scp -i "${KEY_PATH}" -o StrictHostKeyChecking=no install-local-podman.ps1 \
-          "${TARGET_USER}@${TARGET_HOST}:${TARGET_FOLDER}/${REMOTE_SCRIPT}"
-
-        ssh -i "${KEY_PATH}" -o StrictHostKeyChecking=no "${TARGET_USER}@${TARGET_HOST}" \
-          "cd '${TARGET_FOLDER}' && powershell -NoProfile -ExecutionPolicy Bypass -File '${REMOTE_SCRIPT}'"
-
-    - name: 'Download Podman from release URL, do not initialize'
-      if: steps.resolve-artifact.outputs.local_msi == ''
-      shell: bash
-      run: |
-        set -euo pipefail
 
         CMD="podman run --rm -d --name pde2e-podman-run \
           -e TARGET_HOST=$(cat host) \
@@ -203,49 +86,25 @@ runs:
               -rootful 0 \
               -start 0"
 
+        # Add the provider or the default WSL install parameter
         if [[ -n "${{ inputs.podman-provider }}" ]]; then
           CMD+=" -podmanProvider ${{ inputs.podman-provider }}"
         else
           CMD+=" -installWSL 0"
         fi
 
-        echo "$CMD"
-        eval "$CMD"
-        podman logs -f pde2e-podman-run
-
-    - name: 'Configure Podman provider after local install'
-      if: steps.resolve-artifact.outputs.local_msi != ''
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        # Podman is already installed from the local MSI. Reuse podman.ps1 only to
-        # configure the provider / skip WSL install (download URL is unused).
-        CMD="podman run --rm -d --name pde2e-podman-run \
-          -e TARGET_HOST=$(cat host) \
-          -e TARGET_HOST_USERNAME=$(cat username) \
-          -e TARGET_HOST_KEY_PATH=/data/id_rsa \
-          -e TARGET_FOLDER=${{ inputs.target-folder }} \
-          -e TARGET_CLEANUP=${{ inputs.target-cleanup }} \
-          -e TARGET_RESULTS=${{ inputs.results-folder }} \
-          -e OUTPUT_FOLDER=/data \
-          -e DEBUG=${{ inputs.debug-mode }} \
-          -v $PWD:/data:z \
-          ${{ inputs.builder-image }}:${{ inputs.podman-image-tag }}-windows \
-            pd-e2e/podman.ps1 \
-              -downloadUrl https://example.invalid/podman.msi \
-              -targetFolder ${{ inputs.target-folder }} \
-              -resultsFolder ${{ inputs.results-folder }} \
-              -initialize 0 \
-              -rootful 0 \
-              -start 0"
-
-        if [[ -n "${{ inputs.podman-provider }}" ]]; then
-          CMD+=" -podmanProvider ${{ inputs.podman-provider }}"
-        else
-          CMD+=" -installWSL 0"
+        # Pass GitHub token for authenticated Actions artifact downloads (nightly)
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          CMD+=" -githubToken ${GITHUB_TOKEN}"
         fi
 
-        echo "$CMD"
+        # Log without exposing the token
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          echo "${CMD//${GITHUB_TOKEN}/***}"
+        else
+          echo "$CMD"
+        fi
         eval "$CMD"
+
+        # Check logs
         podman logs -f pde2e-podman-run

--- a/.github/actions/download-podman-nightly/action.yml
+++ b/.github/actions/download-podman-nightly/action.yml
@@ -109,7 +109,9 @@ runs:
 
         \$env:Path += ";\$podmanPath"
         \$currentUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-        if (-not \$currentUserPath.Contains(\$podmanPath)) {
+        if ([string]::IsNullOrWhiteSpace(\$currentUserPath)) {
+          [Environment]::SetEnvironmentVariable('Path', \$podmanPath, 'User')
+        } elseif (-not \$currentUserPath.Contains(\$podmanPath)) {
           [Environment]::SetEnvironmentVariable('Path', (\$currentUserPath + ';' + \$podmanPath), 'User')
         }
 

--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -58,6 +58,9 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.rootful == '0' && 'rootless' || 'rootful' }} ${{ matrix.user-networking == '1' && '- user mode networking enabled' || '' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +97,7 @@ jobs:
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
         # Set podman configuration variables from fetched version
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_machine_options || env.DEFAULT_PODMAN_MACHINE_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
@@ -142,6 +146,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -79,7 +79,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'
@@ -97,7 +97,6 @@ jobs:
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print kv[1]"="kv[2]}}' >> $GITHUB_ENV
         # Set podman configuration variables from fetched version
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_machine_options || env.DEFAULT_PODMAN_MACHINE_OPTIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
@@ -146,7 +145,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -58,9 +58,6 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.rootful == '0' && 'rootless' || 'rootful' }} ${{ matrix.user-networking == '1' && '- user mode networking enabled' || '' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -55,9 +55,6 @@ jobs:
     name: ${{ matrix.windows-version }} - Debug
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -26,7 +26,7 @@ on:
         required: true
       podman_options:
         default: 'PODMAN_VERSION=latest,INIT=1,START=1,ROOTFUL=1,NETWORKING=0,PROVIDER=wsl'
-        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest" or a version like "v5.6.2"; for PROVIDER use "wsl" or "hyperv" options.'
+        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest", "nightly", or a version like "v5.6.2"; for PROVIDER use "wsl" or "hyperv" options.'
         type: string
         required: true
       env_vars:
@@ -55,6 +55,9 @@ jobs:
     name: ${{ matrix.windows-version }} - Debug
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +91,7 @@ jobs:
         echo "${PODMAN_OPTS}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.pd_repo_options }}" | awk -F ',' \
@@ -135,6 +139,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'
@@ -91,7 +91,6 @@ jobs:
         echo "${PODMAN_OPTS}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "${{ github.event.inputs.pd_repo_options }}" | awk -F ',' \
@@ -139,7 +138,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -56,7 +56,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'
@@ -91,7 +91,6 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
@@ -129,7 +128,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -56,6 +56,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +91,7 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
@@ -127,6 +129,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -58,6 +58,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -98,6 +99,7 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
     
@@ -141,6 +143,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
         podman-provider: ${{ env.PODMAN_PROVIDER }} 
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -58,7 +58,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'
@@ -99,7 +99,6 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
     
@@ -143,7 +142,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }} 
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -73,7 +73,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'nightly' }}
         file_type: 'msi'
@@ -93,7 +93,6 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
@@ -137,7 +136,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -58,7 +58,6 @@ jobs:
     permissions:
       contents: read
       checks: write
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -26,8 +26,8 @@ on:
         type: 'string'
         required: true
       podman_version:
-        default: 'latest'
-        description: 'Podman version (use "latest" to auto-fetch latest release, or specify version like "v5.6.1")'
+        default: 'nightly'
+        description: 'Podman version (use "nightly" for main branch CI artifacts, "latest" for stable release, or specify version like "v5.6.1")'
         type: string
         required: true
       images_version:
@@ -58,6 +58,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +75,7 @@ jobs:
       id: fetch-podman
       uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
-        version_input: ${{ github.event.inputs.podman_version || 'latest' }}
+        version_input: ${{ github.event.inputs.podman_version || 'nightly' }}
         file_type: 'msi'
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,6 +93,7 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.images_version || env.DEFAULT_IMAGES_VERSIONS }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "PDE2E_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
 
@@ -135,6 +137,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -63,9 +63,6 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
     timeout-minutes: 90
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -63,6 +63,9 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
     timeout-minutes: 90
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -116,6 +119,7 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "PD_URL=${{ github.event.inputs.podman_desktop_url || env.DEFAULT_PD_URL }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
@@ -159,6 +163,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -101,7 +101,7 @@ jobs:
 
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'
@@ -119,7 +119,6 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "PD_URL=${{ github.event.inputs.podman_desktop_url || env.DEFAULT_PD_URL }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.podman_options || env.DEFAULT_PODMAN_OPTIONS }}" | awk -F ',' \
@@ -163,7 +162,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -73,9 +73,6 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
     timeout-minutes: 90
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -82,7 +82,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -85,7 +85,7 @@ jobs:
     steps:
     - name: Fetch latest Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ github.event.inputs.podman_version || 'latest' }}
         file_type: 'msi'
@@ -105,7 +105,6 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }},IMAGE_SIZE=${{ github.event.inputs.image_size || env.DEFAULT_IMAGE_SIZE}}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.host_params || env.DEFAULT_HOST_PARAMS }}" | awk -F ',' \
         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "HOST_PARAMS_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
@@ -157,7 +156,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -73,6 +73,9 @@ jobs:
     name: ${{ matrix.windows-version }} - ${{ matrix.windows-featurepack }}
     timeout-minutes: 90
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +105,7 @@ jobs:
         echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
         echo "PODMAN_PROVIDER=${{ github.event.inputs.podman_provider || env.DEFAULT_PODMAN_PROVIDER }}" >> $GITHUB_ENV
         echo "PODMAN_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "ENV_VARS=${{ github.event.inputs.env_vars || env.DEFAULT_ENV_VARS }},IMAGE_SIZE=${{ github.event.inputs.image_size || env.DEFAULT_IMAGE_SIZE}}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.host_params || env.DEFAULT_HOST_PARAMS }}" | awk -F ',' \
         '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "HOST_PARAMS_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
@@ -153,6 +157,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -27,7 +27,7 @@ on:
         required: true
       podman_options:
         default: 'PODMAN_VERSION=latest,DESKTOP_URL=latest,PROVIDER=wsl,INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
-        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest" or a version like "v5.6.2";for DESKTOP_URL use "latest" or a URL for a x64.exe artifact from https://github.com/podman-desktop/testing-prereleases/tags; for PROVIDER use "wsl" or "hyperv" options.'
+        description: 'Podman configuration options with provider choice. For PODMAN_VERSION use "latest", "nightly", or a version like "v5.6.2";for DESKTOP_URL use "latest" or a URL for a x64.exe artifact from https://github.com/podman-desktop/testing-prereleases/tags; for PROVIDER use "wsl" or "hyperv" options.'
         type: string
         required: true
       env_vars:
@@ -55,6 +55,9 @@ jobs:
     name: ${{ matrix.windows-version }} - Debug
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +117,7 @@ jobs:
         echo "${PODMAN_OPTS}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION" && kv[1] != "DESKTOP_URL") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
+        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "PODMAN_DESKTOP_URL=${{ steps.extract-podman-desktop-url.outputs.podman_desktop_url }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
@@ -175,6 +179,8 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
+        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@aea6ff44f2a4a82da13d22061ce73443a125925d
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -55,9 +55,6 @@ jobs:
     name: ${{ matrix.windows-version }} - Debug
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Fetch Podman version
       id: fetch-podman
-      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@60b05ab5b050c9f8ec8dff7e0377f8bf36c39207
+      uses: redhat-actions/podman-install/.github/actions/fetch-latest-podman-version-windows@6b9121eed76855854291b52c6bfbc278dbdf0288
       with:
         version_input: ${{ steps.extract-version.outputs.podman_version }}
         file_type: 'msi'
@@ -117,7 +117,6 @@ jobs:
         echo "${PODMAN_OPTS}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); if(kv[1] != "PODMAN_VERSION" && kv[1] != "DESKTOP_URL") print "PODMAN_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
         echo "PODMAN_REMOTE_URL=${{ steps.fetch-podman.outputs.download_url }}" >> $GITHUB_ENV
-        echo "PODMAN_LOCAL_INSTALLER=${{ steps.fetch-podman.outputs.local_installer_path }}" >> $GITHUB_ENV
         echo "PODMAN_DESKTOP_URL=${{ steps.extract-podman-desktop-url.outputs.podman_desktop_url }}" >> $GITHUB_ENV
         echo "${{ github.event.inputs.ext_repo_options }}" | awk -F ',' \
          '{for (i=1; i<=NF; i++) {split($i, kv, "="); print "EXT_"kv[1]"="kv[2]}}' >> $GITHUB_ENV
@@ -179,7 +178,7 @@ jobs:
       with:
         podman-image-tag: ${{ env.PDE2E_PODMAN }}
         podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
-        podman-local-installer: ${{ env.PODMAN_LOCAL_INSTALLER }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         podman-provider: ${{ env.PODMAN_PROVIDER }}
 
     - name: Run Podman Desktop Playwright E2E tests


### PR DESCRIPTION
## Summary

Updates Windows E2E workflows to use `fetch-latest-podman-version-windows` from [redhat-actions/podman-install#26](https://github.com/redhat-actions/podman-install/pull/26) (pinned to `6b9121e`). That sub-action resolves Podman installer URLs for releases and for `nightly`/`main` CI artifacts, exposing an Actions `archive_download_url` via `download_url`.

`download-podman-nightly` now forwards that URL plus a GitHub token (`-githubToken`) into `podman.ps1`, so the Windows host downloads nightly artifacts the same way as public MSI release URLs. Affected workflows pass `github_token` into the fetch step and `github-token` into `download-podman-nightly`. The nightly WSL workflow defaults to `podman_version: nightly`.

Depends on a `pde2e-podman` image that supports authenticated Actions artifact downloads (see the matching pde2e-podman PR on `586-switch-pulling-podman-nightly`, https://github.com/odockal/pde2e-podman/pull/13).

Closes partially [podman-desktop/e2e#586](https://github.com/podman-desktop/e2e/issues/586)

## Test plan

- [ ] Windows workflow with `podman_version: latest` (public release MSI URL, no token required for download)
- [ ] Windows workflow with `podman_version: nightly` (Actions artifact URL + token → download/install on Windows)
- [ ] Confirm `podman-desktop-e2e-nightly-windows-wsl` scheduled/dispatch defaults to nightly
- [ ] Confirm workflows use a `pde2e-podman` image tag that includes `-githubToken` support