### PR TITLE
feat(darwin): support non-PD apps in e2e-runner (Kaiden, RHBPD)

### DIFF
--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -440,11 +440,11 @@ else
 fi
 
 if [ -n "$podmanDesktopBinary" ]; then
-    case "$appName" in
-        "Red Hat build of Podman Desktop") binaryEnvVar="PODMAN_DESKTOP_BINARY" ;;
-        "Kaiden")                          binaryEnvVar="KAIDEN_BINARY" ;;
-        *)                                 binaryEnvVar="PODMAN_DESKTOP_BINARY" ;;
-    esac
+    if [[ "${appName,,}" == *"kaiden"* ]]; then
+        binaryEnvVar="KAIDEN_BINARY"
+    else
+        binaryEnvVar="PODMAN_DESKTOP_BINARY"
+    fi
     echo "Setting $binaryEnvVar to: $podmanDesktopBinary"
     export "$binaryEnvVar"="$podmanDesktopBinary"
 elif (( extTests == 1 )); then

--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
         --fork) fork="$2"; shift ;;
         --branch) branch="$2"; shift ;;
         --repo) repo="$2"; shift ;;
-        --appName) appName="$2"; shift ;;
+        --appName) appName="${2//\'/}"; shift ;;
         --gitProviderUrl) gitProviderUrl="$2"; shift ;;
         --extRepo) extRepo="$2"; shift ;;
         --extTests) extTests="$2"; shift ;;
@@ -322,6 +322,15 @@ if (( cleanMachine == 1 )); then
     # remove old podman system connections from user space
     rm -rf ~/.config/containers/podman-connections.json*
     rm -rf ~/.config/containers/podman
+    # Detach any stale DMG volumes from previous runs
+    for vol in "/Volumes/${appName}"*; do
+        if [ -d "$vol" ]; then
+            echo "Detaching stale volume: $vol"
+            hdiutil detach "$vol" 2>&1 \
+                || hdiutil detach -force "$vol" 2>&1 \
+                || echo "Warning: Could not detach $vol — may interfere with test"
+        fi
+    done
     echo "Cleanup finished..."
 fi
 
@@ -387,7 +396,20 @@ if [ -z "$pdPath" ]; then
             exit 1
         fi
         pdVolumePath=$(find /Volumes -name "*${appName} ${version}*" -maxdepth 1 | head -1)
+        if [ -z "$pdVolumePath" ]; then
+            echo "Volume not found with version pattern, trying without version..."
+            matches=$(find /Volumes -name "*${appName}*" -maxdepth 1)
+            matchCount=$(echo "$matches" | grep -c . || true)
+            if [ "$matchCount" -gt 1 ]; then
+                echo "Warning: Multiple volumes matched '${appName}': $matches"
+            fi
+            pdVolumePath=$(echo "$matches" | head -1)
+        fi
         echo "Volume path: $pdVolumePath"
+        if [ -z "$pdVolumePath" ]; then
+            echo "Error: Could not find mounted volume for ${appName}"
+            exit 1
+        fi
         sudo rm -rf "/Applications/${appName}.app"
         sudo cp -R "$pdVolumePath/${appName}.app" /Applications
         hdiutil detach "$pdVolumePath"
@@ -418,8 +440,13 @@ else
 fi
 
 if [ -n "$podmanDesktopBinary" ]; then
-    echo "Setting PODMAN_DESKTOP_BINARY to: $podmanDesktopBinary"
-    export PODMAN_DESKTOP_BINARY="$podmanDesktopBinary"
+    case "$appName" in
+        "Red Hat build of Podman Desktop") binaryEnvVar="PODMAN_DESKTOP_BINARY" ;;
+        "Kaiden")                          binaryEnvVar="KAIDEN_BINARY" ;;
+        *)                                 binaryEnvVar="PODMAN_DESKTOP_BINARY" ;;
+    esac
+    echo "Setting $binaryEnvVar to: $podmanDesktopBinary"
+    export "$binaryEnvVar"="$podmanDesktopBinary"
 elif (( extTests == 1 )); then
     echo "Setting PODMAN_DESKTOP_ARGS to: $workingDir/$repo"
     export PODMAN_DESKTOP_ARGS="$workingDir/$repo"


### PR DESCRIPTION
## Summary

Enables the macOS e2e-runner to work with applications other than Podman Desktop (e.g. Kaiden, Red Hat build of Podman Desktop) by fixing several issues discovered during Kaiden Mac lab pipeline setup.

- **Strip literal single quotes from `--appName`** — The Tekton task wraps appName in single quotes for shell safety. When `entrypoint.sh` evals the command, these can become literal characters causing `find /Volumes` to fail.
- **Detach stale DMG volumes during `cleanMachine`** — Previous failed runs leave mounted volumes under `/Volumes/<appName>*`. macOS appends ` 1` suffixes on collision, causing volume path resolution to fail. Now attempts force-detach with logged warnings.
- **Export app-specific binary env var based on `--appName`** — Instead of always exporting `PODMAN_DESKTOP_BINARY`, the runner now exports the correct env var for each app (`KAIDEN_BINARY` for Kaiden).
- **Add volume path fallback** — When the version extracted from the DMG URL doesn't match the volume name, falls back to searching by appName only, with a warning on multiple matches and fail-fast on no match.

### Related PRs

- Codesign / resignApp: #627 (closes #579)
- Deferred secrets: #628

### Testing

Successfully tested on mac-10 (M4 Pro, macOS 26.3) via OpenShift Tekton pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)