### PR TITLE
fix: update podman version source from removed podman5.json to podman.son

### DIFF
--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
     - name: Get Podman version used by Desktop
       run: |
-        version=$(curl https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
+        version=$(curl -s https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/extensions/podman/packages/extension/src/podman.json | jq -r '[.versions[].version] | sort_by(split(".") | map(tonumber)) | last')
         echo "Default Podman Version from Podman Desktop: ${version}"
         echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
 


### PR DESCRIPTION
The podman-desktop repo renamed podman5.json to podman.json in the main branch and changed the structure to support multiple versions (v5, v6). This broke the nightly HyperV workflow which was fetching the old file.

issue: https://github.com/podman-desktop/e2e/issues/609