### PR TITLE
ci: install Podman via run-playwright-test

### DIFF
--- a/.github/actions/run-playwright-test/action.yml
+++ b/.github/actions/run-playwright-test/action.yml
@@ -97,7 +97,7 @@ inputs:
   podman-path:
     description: 'Whether to pass -podmanPath from results/podman-location.log (ignored when podman-download-url is set).'
     required: false
-    default: 'false'
+    default: 'true'
   podman-download-url:
     description: 'URL for e2e-runner to download and install Podman on the remote host.'
     required: false

--- a/.github/actions/run-playwright-test/action.yml
+++ b/.github/actions/run-playwright-test/action.yml
@@ -95,9 +95,13 @@ inputs:
     required: false
     default: 'false'
   podman-path:
-    description: 'Whether to include podman path parameter.'
+    description: 'Whether to pass -podmanPath from results/podman-location.log (ignored when podman-download-url is set).'
     required: false
-    default: 'true'
+    default: 'false'
+  podman-download-url:
+    description: 'URL for e2e-runner to download and install Podman on the remote host.'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -151,7 +155,10 @@ runs:
         fi
 
         PODMAN_PATH=""
-        if [ "${{ inputs.podman-path }}" != "false" ]; then
+        PODMAN_DOWNLOAD_URL_PARAM=""
+        if [ -n "${{ inputs.podman-download-url }}" ]; then
+          PODMAN_DOWNLOAD_URL_PARAM="-podmanDownloadUrl ${{ inputs.podman-download-url }}"
+        elif [ "${{ inputs.podman-path }}" != "false" ]; then
           PODMAN_PATH="-podmanPath $(cat results/podman-location.log)"
         fi
 
@@ -170,6 +177,7 @@ runs:
                 -targetFolder ${{ inputs.target-folder }} \
                 -resultsFolder ${{ inputs.results-folder }} \
                 ${PODMAN_PATH} \
+                ${PODMAN_DOWNLOAD_URL_PARAM} \
                 ${PD_URL_PARAM} \
                 ${PD_PATH} \
                 -fork ${{ inputs.fork-repo }} \

--- a/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
+++ b/.github/workflows/desktop-e2e-podman-windows-matrix.yaml
@@ -137,16 +137,12 @@ jobs:
         fork: ${{ env.FORK }}
         branch: ${{ env.BRANCH }}
 
-    - name: Download Podman nightly, do not initialize and start
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         fork-repo: ${{ env.FORK }}
         branch-name: ${{ env.BRANCH }}
         npm-target: ${{ env.NPM_TARGET }}

--- a/.github/workflows/desktop-e2e-test-job-windows.yaml
+++ b/.github/workflows/desktop-e2e-test-job-windows.yaml
@@ -130,16 +130,12 @@ jobs:
         fork: ${{ env.FORK }}
         branch: ${{ env.BRANCH }}
 
-    - name: Download Podman nightly, do not initialize
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
         fork-repo: ${{ env.PD_FORK }}
         branch-name: ${{ env.PD_BRANCH }}
         ext-repo: ${{ env.EXT_REPO }}

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -122,16 +122,12 @@ jobs:
     - name: Emulate X session
       uses: podman-desktop/e2e/.github/actions/emulate-x-session@main
 
-    - name: Download Podman latest, do not initialize and start
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         fork-repo: ${{ env.FORK }}
         branch-name: ${{ env.BRANCH }}
         npm-target: ${{ env.NPM_TARGET }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -138,7 +138,7 @@ jobs:
 
 
     - name: Run Podman Desktop Playwright E2E tests
-      uses: podman-desktop/e2e/.github/actions/run-playwright-test@issue-598
+      uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
         podman-download-url: ${{ env.PODMAN_URL }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -136,17 +136,12 @@ jobs:
         fork: ${{ env.FORK }}
         branch: ${{ env.BRANCH }}
 
-    - name: Download Podman latest, do not initialize and start
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
-        podman-provider: ${{ env.PODMAN_PROVIDER }} 
 
     - name: Run Podman Desktop Playwright E2E tests
-      uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
+      uses: podman-desktop/e2e/.github/actions/run-playwright-test@issue-598
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         fork-repo: ${{ env.FORK }}
         branch-name: ${{ env.BRANCH }}
         npm-target: ${{ env.NPM_TARGET }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -130,16 +130,13 @@ jobs:
         fork: ${{ env.FORK }}
         branch: ${{ env.BRANCH }}
 
-    - name: Download Podman nightly, do not initialize and start
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
-      uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
+      # TEMP (#598 test): pin this branch; revert to @main when merging
+      uses: podman-desktop/e2e/.github/actions/run-playwright-test@issue-598
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         fork-repo: ${{ env.FORK }}
         branch-name: ${{ env.BRANCH }}
         npm-target: ${{ env.NPM_TARGET }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -132,8 +132,7 @@ jobs:
 
 
     - name: Run Podman Desktop Playwright E2E tests
-      # TEMP (#598 test): pin this branch; revert to @main when merging
-      uses: podman-desktop/e2e/.github/actions/run-playwright-test@issue-598
+      uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
         podman-download-url: ${{ env.PODMAN_URL }}

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -154,16 +154,12 @@ jobs:
     - name: Emulate X session
       uses: podman-desktop/e2e/.github/actions/emulate-x-session@main
 
-    - name: Download Podman nightly, do not initialize
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         podman-desktop-url: ${{ env.PD_URL }}
         fork-repo: ${{ env.PD_FORK }}
         branch-name: ${{ env.PD_BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -148,16 +148,12 @@ jobs:
         branch: ${{ env.PD_BRANCH }}
         env-vars: ${{ env.ENV_VARS }}
 
-    - name: Download Podman nightly, do not initialize
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_URL }}
         fork-repo: ${{ env.PD_FORK }}
         branch-name: ${{ env.PD_BRANCH }}
         npm-target: ${{ env.NPM_TARGET }}

--- a/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
+++ b/.github/workflows/prerelease-desktop-e2e-debug-job-windows.yaml
@@ -170,16 +170,12 @@ jobs:
     - name: Emulate X session
       uses: podman-desktop/e2e/.github/actions/emulate-x-session@main
 
-    - name: Download Podman nightly, do not initialize
-      uses: podman-desktop/e2e/.github/actions/download-podman-nightly@main
-      with:
-        podman-image-tag: ${{ env.PDE2E_PODMAN }}
-        podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
 
     - name: Run Podman Desktop Playwright E2E tests
       uses: podman-desktop/e2e/.github/actions/run-playwright-test@main
       with:
         e2e-runner-tag: ${{ env.PDE2E_RUNNER }}
+        podman-download-url: ${{ env.PODMAN_REMOTE_URL }}
         podman-desktop-url: ${{ env.PODMAN_DESKTOP_URL }}
         fork-repo: ${{ env.PD_FORK }}
         branch-name: ${{ env.PD_BRANCH }}


### PR DESCRIPTION
## Summary
- Add `podman-download-url` to `run-playwright-test` and pass it as `-podmanDownloadUrl` to e2e-runner
- Stop calling `download-podman-nightly` from Windows e2e workflows in this repo
- Keep `download-podman-nightly` for external consumers (bootc, ai-lab, etc.)

Closes https://github.com/podman-desktop/e2e/issues/598

## Test plan
- [x] [WSL nightly](https://github.com/podman-desktop/e2e/actions/runs/30895310524) with `@issue-598` 
- [x] [HyperV nightly](https://github.com/podman-desktop/e2e/actions/runs/30895287231) with `@issue-598` 
- [x] Revert action refs to `@main`