### PR TITLE
feat(ci): add slack notifications for scheduled e2e workflow runs

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Red Hat, Inc.
+# Copyright (C) 2026 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,59 @@
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Notify Slack'
+description: 'Posts a workflow run status message to a Slack Workflow Builder webhook'
+
+inputs:
+  webhook-url:
+    description: 'Slack Workflow Builder webhook URL'
+    required: true
+    type: string
+  status:
+    description: 'Run status/conclusion to report, e.g. job.status'
+    required: true
+    type: string
+  workflow-name:
+    description: 'Overrides the reported workflow name, useful to disambiguate matrix jobs. Defaults to "<workflow> / <job>"'
+    required: false
+    default: ''
+    type: string
+  branch:
+    description: 'Branch under test, if relevant'
+    required: false
+    default: ''
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send Slack notification
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        JOB_STATUS: ${{ inputs.status }}
+        BRANCH_NAME: ${{ inputs.branch }}
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+      run: |
+        payload=$(jq -n \
+          --arg workflow_name "${WORKFLOW_NAME:-$GITHUB_WORKFLOW / $GITHUB_JOB}" \
+          --arg repo "$GITHUB_REPOSITORY" \
+          --arg branch "$BRANCH_NAME" \
+          --arg status "$JOB_STATUS" \
+          --arg actor "$GITHUB_ACTOR" \
+          --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+          '{workflow_name:$workflow_name, repo:$repo, branch:$branch, status:$status, actor:$actor, run_url:$run_url}')
+        curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -191,7 +191,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -188,3 +188,12 @@ jobs:
           results/*
           **/workflow-run-attributes.json
           **/junit-infra-failure-report.xml
+
+    - name: Notify Slack
+      if: always()
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        workflow-name: "${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }} - ${{ matrix.podman-provider }})"
+        branch: ${{ env.BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -191,7 +191,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -202,3 +202,12 @@ jobs:
           results/*
           **/workflow-run-attributes.json
           **/junit-infra-failure-report.xml
+
+    - name: Notify Slack
+      if: always()
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        workflow-name: "${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})"
+        branch: ${{ env.BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -198,7 +198,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -198,21 +198,9 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      env:
-        WORKFLOW_NAME: ${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})
-        REPO_NAME: ${{ github.repository }}
-        BRANCH_NAME: ${{ env.BRANCH }}
-        JOB_STATUS: ${{ job.status }}
-        ACTOR_NAME: ${{ github.actor }}
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      run: |
-        payload=$(jq -n \
-          --arg workflow_name "$WORKFLOW_NAME" \
-          --arg repo "$REPO_NAME" \
-          --arg branch "$BRANCH_NAME" \
-          --arg status "$JOB_STATUS" \
-          --arg actor "$ACTOR_NAME" \
-          --arg run_url "$RUN_URL" \
-          '{workflow_name:$workflow_name, repo:$repo, branch:$branch, status:$status, actor:$actor, run_url:$run_url}')
-        curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        workflow-name: "${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})"
+        branch: ${{ env.BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -198,7 +198,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -195,3 +195,24 @@ jobs:
           results/*
           **/workflow-run-attributes.json
           **/junit-infra-failure-report.xml
+
+    - name: Notify Slack
+      if: always()
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})
+        REPO_NAME: ${{ github.repository }}
+        BRANCH_NAME: ${{ env.BRANCH }}
+        JOB_STATUS: ${{ job.status }}
+        ACTOR_NAME: ${{ github.actor }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      run: |
+        payload=$(jq -n \
+          --arg workflow_name "$WORKFLOW_NAME" \
+          --arg repo "$REPO_NAME" \
+          --arg branch "$BRANCH_NAME" \
+          --arg status "$JOB_STATUS" \
+          --arg actor "$ACTOR_NAME" \
+          --arg run_url "$RUN_URL" \
+          '{workflow_name:$workflow_name, repo:$repo, branch:$branch, status:$status, actor:$actor, run_url:$run_url}')
+        curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -229,7 +229,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -229,7 +229,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -226,3 +226,12 @@ jobs:
           results/*
           **/workflow-run-attributes.json
           **/junit-infra-failure-report.xml
+
+    - name: Notify Slack
+      if: always()
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        workflow-name: "${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})"
+        branch: ${{ env.PD_BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -197,3 +197,11 @@ jobs:
       with:
         name: linux
         path: ./**/tests/**/output/
+
+    - name: Notify Slack
+      if: always()
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        branch: ${{ env.PD_BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -197,3 +197,12 @@ jobs:
         name: ${{ env.PODMAN_PROVIDER }}-win-${{ matrix.windows-version }}${{ matrix.windows-featurepack }}
         path: |
           results/*
+
+    - name: Notify Slack
+      if: always()
+      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      with:
+        webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        status: ${{ job.status }}
+        workflow-name: "${{ github.workflow }} (Windows ${{ matrix.windows-version }} ${{ matrix.windows-featurepack }})"
+        branch: ${{ env.PD_BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -200,7 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
-      uses: podman-desktop/e2e/.github/actions/notify-slack@main
+      uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -168,3 +168,12 @@ jobs:
             **/junit-playwright-results.xml
             **/workflow-run-attributes.json
             **/junit-infra-failure-report.xml
+
+      - name: Notify Slack
+        if: always()
+        uses: podman-desktop/e2e/.github/actions/notify-slack@main
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          workflow-name: "${{ github.workflow }} (Fedora ${{ matrix.fedora-version }})"
+          branch: ${{ env.BRANCH }}

--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
-        uses: podman-desktop/e2e/.github/actions/notify-slack@main
+        uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}

--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
-        uses: podman-desktop/e2e/.github/actions/notify-slack@add-slack-notification-wsl-e2e
+        uses: podman-desktop/e2e/.github/actions/notify-slack@main
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}


### PR DESCRIPTION
- Add a `notify-slack` composite action that posts run status to a Slack Workflow Builder webhook
- Wire it into the scheduled/nightly e2e workflows

Closes https://github.com/containers/podman-desktop-internal/issues/1019