### PR TITLE
fix(ci): surface Slack notification failures without breaking e2e jobs

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -56,4 +56,4 @@ runs:
           --arg actor "$GITHUB_ACTOR" \
           --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           '{workflow_name:$workflow_name, repo:$repo, branch:$branch, status:$status, actor:$actor, run_url:$run_url}')
-        curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+        curl -sS --fail-with-body --connect-timeout 10 --max-time 30 -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/podman-desktop-e2e-kubernetes.yaml
+++ b/.github/workflows/podman-desktop-e2e-kubernetes.yaml
@@ -191,6 +191,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-hyperv.yaml
@@ -205,6 +205,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
+++ b/.github/workflows/podman-desktop-e2e-nightly-windows-wsl.yaml
@@ -198,6 +198,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-remote-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-remote-windows.yaml
@@ -229,6 +229,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-linux.yaml
@@ -200,6 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
+++ b/.github/workflows/podman-desktop-e2e-stress-ui-windows.yaml
@@ -200,6 +200,7 @@ jobs:
 
     - name: Notify Slack
       if: always()
+      continue-on-error: true
       uses: podman-desktop/e2e/.github/actions/notify-slack@main
       with:
         webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/podman-desktop-e2e-testing-farm.yaml
+++ b/.github/workflows/podman-desktop-e2e-testing-farm.yaml
@@ -171,6 +171,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
+        continue-on-error: true
         uses: podman-desktop/e2e/.github/actions/notify-slack@main
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
curl exits 0 on 4xx/5xx responses and had no timeout, so a broken webhook silently dropped notifications or could hang the job. Add --fail-with-body and finite timeouts to the notify-slack action, and continue-on-error: true to each caller so a Slack outage no longer overrides the E2E job's actual result.

Addresses CodeRabbit review comment on #623.