### PR TITLE
feat(darwin): add --resignApp param for ad-hoc code signing after DMG install

### DIFF
--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -395,15 +395,18 @@ if [ -z "$pdPath" ]; then
         appPath="/Applications/${appName}.app"
         sudo xattr -r -d com.apple.quarantine "$appPath" 2>/dev/null || true
         if (( resignApp == 1 )); then
+            if codesign --verify --deep --verbose=2 "$appPath" 2>/dev/null; then
+                existingSig=$(codesign -dv "$appPath" 2>&1 | grep 'Authority=' | head -1 || true)
+                echo "Warning: $appPath already has a valid signature: $existingSig"
+            fi
             echo "Re-signing $appPath with ad-hoc signature..."
             sudo codesign --force --deep --sign - "$appPath"
-        else
-            if ! codesign --verify --deep --verbose=2 "$appPath"; then
-                echo "ERROR: Codesign verification failed for $appPath"
-                echo "The app will likely fail to launch on macOS 26+ via SSH."
-                echo "Re-run with --resignApp 1 to apply an ad-hoc signature."
-                exit 1
-            fi
+        fi
+        if ! codesign --verify --deep --verbose=2 "$appPath"; then
+            echo "ERROR: Codesign verification failed for $appPath"
+            echo "The app will likely fail to launch on macOS 26+ via SSH."
+            echo "Re-run with --resignApp 1 to apply an ad-hoc signature."
+            exit 1
         fi
         podmanDesktopBinary="$appPath/Contents/MacOS/${appName}"
     else

--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -40,6 +40,7 @@ saveTraces=1
 cleanMachine=1
 scriptPaths=""
 podmanDownloadUrl=""
+resignApp=0
 debugScript=0
 
 while [[ $# -gt 0 ]]; do
@@ -69,6 +70,7 @@ while [[ $# -gt 0 ]]; do
         --cleanMachine) cleanMachine="$2"; shift ;;
         --scriptPaths) scriptPaths="$2"; shift ;;
         --podmanDownloadUrl) podmanDownloadUrl="$2"; shift ;;
+        --resignApp) resignApp="$2"; shift ;;
         --debugScript) debugScript="$2"; shift ;;
         *) ;;
     esac
@@ -106,6 +108,7 @@ if [ "$debugScript" == "1" ]; then
     echo "cleanMachine=$cleanMachine"
     echo "scriptPaths=$scriptPaths"
     echo "podmanDownloadUrl=$podmanDownloadUrl"
+    echo "resignApp=$resignApp"
     echo "debugScript=$debugScript"
 fi
 
@@ -385,12 +388,23 @@ if [ -z "$pdPath" ]; then
         fi
         pdVolumePath=$(find /Volumes -name "*${appName} ${version}*" -maxdepth 1 | head -1)
         echo "Volume path: $pdVolumePath"
+        sudo rm -rf "/Applications/${appName}.app"
         sudo cp -R "$pdVolumePath/${appName}.app" /Applications
         hdiutil detach "$pdVolumePath"
         # codesign the extracted app
         appPath="/Applications/${appName}.app"
-        # sudo codesign --force --deep --sign - "$appPath"
-        codesign --verify --deep --verbose=2 "$appPath"
+        sudo xattr -r -d com.apple.quarantine "$appPath" 2>/dev/null || true
+        if (( resignApp == 1 )); then
+            echo "Re-signing $appPath with ad-hoc signature..."
+            sudo codesign --force --deep --sign - "$appPath"
+        else
+            if ! codesign --verify --deep --verbose=2 "$appPath"; then
+                echo "ERROR: Codesign verification failed for $appPath"
+                echo "The app will likely fail to launch on macOS 26+ via SSH."
+                echo "Re-run with --resignApp 1 to apply an ad-hoc signature."
+                exit 1
+            fi
+        fi
         podmanDesktopBinary="$appPath/Contents/MacOS/${appName}"
     else
         echo "Nor pdUrl or pdPath is set, continue in development mode..."

--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -404,7 +404,6 @@ if [ -z "$pdPath" ]; then
         fi
         if ! codesign --verify --deep --verbose=2 "$appPath"; then
             echo "ERROR: Codesign verification failed for $appPath"
-            echo "The app will likely fail to launch on macOS 26+ via SSH."
             echo "Re-run with --resignApp 1 to apply an ad-hoc signature."
             exit 1
         fi

--- a/e2e-runner/tkn/task.yaml
+++ b/e2e-runner/tkn/task.yaml
@@ -146,6 +146,9 @@ spec:
   - name: debug-script
     description: Print all script parameters for debugging
     default: '0'
+  - name: resign-app
+    description: Re-sign installed app with ad-hoc signature (macOS only)
+    default: '0'
 
   results:
   - name: duration
@@ -294,6 +297,7 @@ spec:
           if [[ -n "$(params.podman-provider)" ]]; then
             cmd="$cmd --podmanProvider $(params.podman-provider) "
           fi
+          cmd="$cmd --resignApp $(params.resign-app) "
         fi
       fi
 


### PR DESCRIPTION
## Summary

- Add `--resignApp` flag (default 0) that re-signs the installed app with an ad-hoc signature after DMG installation, fixing Gatekeeper blocks on macOS 26+ when launching via SSH
- Remove old app bundle before copy to prevent hybrid bundles from `cp -R` overlay
- Strip quarantine attribute after install; fail fast with actionable error if codesign verification fails when signing is disabled
- Wire `resign-app` parameter through the Tekton task definition

## Test plan

- [ ] Run pipeline with `--resignApp 1` on macOS 26+ target — app should launch without Gatekeeper block
- [ ] Run pipeline without `--resignApp` on a vendor-signed DMG — codesign verify should pass
- [ ] Run pipeline without `--resignApp` on an unsigned DMG — should fail fast with "Re-run with --resignApp 1" message

Closes https://github.com/podman-desktop/e2e/issues/579

🤖 Generated with [Claude Code](https://claude.com/claude-code)