### PR TITLE
Clean up pde2e naming vestiges in e2e-runner

### DIFF
--- a/e2e-runner/common/unix/common.sh
+++ b/e2e-runner/common/unix/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Common bash utility functions for pde2e-image macOS scripts
+# Common bash utility functions for e2e-runner macOS/RHEL scripts
 
 # Detect file type and return MIME type
 detect_file_type() {

--- a/e2e-runner/common/windows/common.ps1
+++ b/e2e-runner/common/windows/common.ps1
@@ -1,4 +1,4 @@
-# Common PowerShell utility functions for pde2e-image Windows scripts
+# Common PowerShell utility functions for e2e-runner Windows scripts
 
 # Function to check if a command is available
 function Command-Exists($command) {

--- a/e2e-runner/lib/darwin/runner.sh
+++ b/e2e-runner/lib/darwin/runner.sh
@@ -132,7 +132,7 @@ userProfile="$HOME"
 toolsInstallDir="$userProfile/tools"
 
 # Output file for built podman desktop binary
-outputFile="pde2e-binary-path.log"
+outputFile="binary-path.log"
 
 # Determine the system's arch
 architecture=$(uname -m)

--- a/e2e-runner/lib/rhel/runner.sh
+++ b/e2e-runner/lib/rhel/runner.sh
@@ -122,7 +122,7 @@ userProfile="$HOME"
 toolsInstallDir="$userProfile/tools"
 
 # Output file for built podman desktop binary
-outputFile="pde2e-binary-path.log"
+outputFile="binary-path.log"
 
 # Determine the system's arch
 architecture=$(uname -m)

--- a/e2e-runner/tkn/task-rhel-display.yaml
+++ b/e2e-runner/tkn/task-rhel-display.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: pde2e-image-rhel-display
+  name: e2e-runner-rhel-display
   labels:
     app.kubernetes.io/version: "0.1"
     redhat.com/product: podman-desktop
@@ -17,7 +17,7 @@ spec:
   description: >-
     This task sets up a headless GNOME session on a RHEL target host using
     gnome-remote-desktop-headless.service. It must run before the
-    pde2e-runner-rhel task so that a Wayland compositor is ready when
+    e2e-runner-image task so that a Wayland compositor is ready when
     the runner's setup_display() function searches for the mutter auth file.
 
   workspaces:
@@ -35,7 +35,7 @@ spec:
     description: path on workspace to find resources to connect to the target machine
   # Task parameters
   - name: image-version
-    description: pde2e-runner image version
+    description: e2e-runner image version
     default: '0.1.1'
   - name: results-folder
     description: directory for setup logs and artifacts
@@ -53,7 +53,7 @@ spec:
 
   steps:
   - name: display-setup
-    image: quay.io/odockal/pde2e-image:v$(params.image-version)-rhel
+    image: ghcr.io/podman-desktop/e2e-runner:v$(params.image-version)-rhel
     imagePullPolicy: Always
     script: |
       #!/bin/bash


### PR DESCRIPTION
## Summary
- Update stale `pde2e-image` comments in `common/unix/common.sh` and `common/windows/common.ps1`
- Rename the unused `pde2e-binary-path.log` output filename in `lib/darwin/runner.sh` and `lib/rhel/runner.sh` to `binary-path.log`
- Rename the RHEL display Tekton task from `pde2e-image-rhel-display` to `e2e-runner-rhel-display` and point its image at `ghcr.io/podman-desktop/e2e-runner`

Closes #602